### PR TITLE
fix: ensure ControllerConfig initializes globals on every reconcile

### DIFF
--- a/internal/controller/chunksgenerator_controller.go
+++ b/internal/controller/chunksgenerator_controller.go
@@ -65,7 +65,7 @@ type ChunksGeneratorReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/reconcile
 func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("reconciling ChunksGenerator")
+	logger.Info("reconciling", "controller", ChunksGeneratorControllerName)
 
 	// check if config CR is healthy
 	isHealthy, err := IsConfigCRHealthy(ctx, r.Client, req.Namespace)
@@ -102,6 +102,10 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	fs, err := filestore.New(ctx, cacheDirectory, dataStorageBucket)
 	if err != nil {
+		if IsAWSClientNotInitializedError(err) {
+			logger.Info("ControllerConfig has not initialized AWS clients yet, will try again in a bit ...")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
 		logger.Error(err, "failed to create filestore")
 		return r.handleError(ctx, chunksGeneratorCR, err)
 	}
@@ -183,17 +187,12 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		logger.Info("no files were chunked, no need to add force reconcile label to UnstructuredDataProduct CR")
 	}
 
+	chunksGeneratorKey := client.ObjectKeyFromObject(chunksGeneratorCR)
 	successMessage := fmt.Sprintf("successfully reconciled chunks generator: %s", chunksGeneratorCR.Name)
-	key := client.ObjectKey{Namespace: chunksGeneratorCR.Namespace, Name: chunksGeneratorCR.Name}
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		res := &operatorv1alpha1.ChunksGenerator{}
-		if err := r.Get(ctx, key, res); err != nil {
-			return err
-		}
-		res.UpdateStatus(successMessage, nil)
-		return r.Status().Update(ctx, res)
+	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, chunksGeneratorKey, func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }, func(obj client.Object) {
+		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus(successMessage, nil)
 	}); err != nil {
-		logger.Error(err, "failed to update ChunksGenerator CR status", "namespace", key.Namespace, "name", key.Name)
+		logger.Error(err, "failed to update ChunksGenerator CR status", "namespace", chunksGeneratorKey.Namespace, "name", chunksGeneratorKey.Name)
 		return r.handleError(ctx, chunksGeneratorCR, err)
 	}
 	logger.Info("successfully updated ChunksGenerator CR status", "status", chunksGeneratorCR.Status)
@@ -385,17 +384,12 @@ func (r *ChunksGeneratorReconciler) handleError(ctx context.Context, chunksGener
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
-	key := client.ObjectKeyFromObject(chunksGeneratorCR)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.ChunksGenerator{}
-		if getErr := r.Get(ctx, key, latest); getErr != nil {
-			return getErr
-		}
-		latest.UpdateStatus("", reconcileErr)
-		return r.Status().Update(ctx, latest)
-	}); err != nil {
-		logger.Error(err, "failed to update ChunksGenerator CR status")
-		return ctrl.Result{}, err
+	chunksGeneratorKey := client.ObjectKeyFromObject(chunksGeneratorCR)
+	if updateErr := controllerutils.StatusUpdateWithRetry(ctx, r.Client, chunksGeneratorKey, func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }, func(obj client.Object) {
+		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus("", reconcileErr)
+	}); updateErr != nil {
+		logger.Error(updateErr, "failed to update ChunksGenerator CR status")
+		return ctrl.Result{}, updateErr
 	}
 	return ctrl.Result{}, reconcileErr
 }

--- a/internal/controller/config_utils.go
+++ b/internal/controller/config_utils.go
@@ -2,11 +2,35 @@ package controller
 
 import (
 	"context"
+	"strings"
 
 	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// AWS client "not initialized" error messages (from pkg/awsclienthandler).
+const (
+	errMsgS3NotInitialized      = "S3 client not initialized yet"
+	errMsgSQSNotInitialized     = "SQS client not initialized yet"
+	errMsgPresignNotInitialized = "presign client not initialized yet"
+)
+
+// IsAWSClientNotInitializedError returns true if err indicates an AWS client (S3, SQS, or presign)
+// is not initialized yet. Used to requeue without error when ControllerConfig has not run yet at startup.
+func IsAWSClientNotInitializedError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, errMsgS3NotInitialized) ||
+		strings.Contains(msg, errMsgSQSNotInitialized) ||
+		strings.Contains(msg, errMsgPresignNotInitialized)
+}
+
+// IsControllerConfigGlobalsSet returns true if the controller package globals (cacheDirectory,
+// dataStorageBucket) have been set by ControllerConfig Reconcile. When false, filestore.New
+// would be called with empty paths and fail before reaching GetS3Client(), so we requeue early.
+func IsControllerConfigGlobalsSet(cacheDir, dataBucket string) bool {
+	return cacheDir != "" && dataBucket != ""
+}
 
 func IsConfigCRHealthy(ctx context.Context, kubeClient client.Client, namespace string) (bool, error) {
 	controllerConfigCR := &operatorv1alpha1.ControllerConfig{}

--- a/internal/controller/controllerconfig_controller.go
+++ b/internal/controller/controllerconfig_controller.go
@@ -83,11 +83,10 @@ func (r *ControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	config := configList.Items[0]
 
-	// Skip reconciliation if we've already processed this generation successfully
-	if config.Status.LastAppliedGeneration == config.Generation && config.IsHealthy() {
-		logger.Info("config already reconciled for current generation, skipping")
-		return ctrl.Result{}, nil
-	}
+	// Always set globals from config so they are populated on every Reconcile (including after process restart).
+	ingestionBucket = config.Spec.UnstructuredDataProcessingConfig.IngestionBucket
+	dataStorageBucket = config.Spec.UnstructuredDataProcessingConfig.DataStorageBucket
+	cacheDirectory = config.Spec.UnstructuredDataProcessingConfig.CacheDirectory
 
 	unstructuredSecret := &corev1.Secret{}
 	if config.Spec.UnstructuredSecret != "" {
@@ -101,6 +100,30 @@ func (r *ControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
+	doclingServeURL := config.Spec.UnstructuredDataProcessingConfig.DoclingServeURL
+
+	doclingConfig := &docling.ClientConfig{
+		URL:                   doclingServeURL,
+		MaxConcurrentRequests: int64(config.Spec.UnstructuredDataProcessingConfig.MaxConcurrentDoclingTasks),
+	}
+
+	doclingKey := string(unstructuredSecret.Data["DOCLING_USER_KEY"])
+	if doclingKey != "" {
+		doclingConfig.Key = doclingKey
+	}
+
+	// initialize the docling client
+	doclingClient = docling.NewClientFromURL(doclingConfig)
+
+	langchainClient = langchain.NewClient(
+		langchain.ClientConfig{
+			MaxConcurrentRequests: int64(config.Spec.UnstructuredDataProcessingConfig.MaxConcurrentLangchainTasks),
+		},
+	)
+
+	logger.Info(fmt.Sprintf("Ingestion bucket: %s, Data storage bucket: %s, Cache directory: %s",
+		ingestionBucket, dataStorageBucket, cacheDirectory))
+
 	awsEndpoint := string(unstructuredSecret.Data["AWS_ENDPOINT"])
 	if awsEndpoint != "" {
 		// generate AWS clients now
@@ -111,23 +134,15 @@ func (r *ControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			SessionToken:    string(unstructuredSecret.Data["AWS_SESSION_TOKEN"]),
 			Endpoint:        awsEndpoint,
 		}
-		// create SQS client
-		_, err := awsclienthandler.NewSQSClientFromConfig(ctx, &awsConfig)
-		if err != nil {
+		if _, err := awsclienthandler.NewSQSClientFromConfig(ctx, &awsConfig); err != nil {
 			return ctrl.Result{}, err
 		}
 		logger.Info("SQS client created ...")
-
-		// create S3 client
-		_, err = awsclienthandler.NewS3ClientFromConfig(ctx, &awsConfig)
-		if err != nil {
+		if _, err := awsclienthandler.NewS3ClientFromConfig(ctx, &awsConfig); err != nil {
 			return ctrl.Result{}, err
 		}
 		logger.Info("S3 client created ...")
-
-		// create presign client
-		_, err = awsclienthandler.NewPresignClient(ctx)
-		if err != nil {
+		if _, err := awsclienthandler.NewPresignClient(ctx); err != nil {
 			return ctrl.Result{}, err
 		}
 		logger.Info("Presign client created ...")
@@ -172,42 +187,13 @@ func (r *ControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 			return ctrl.Result{}, err
 		}
-
-		logger.Info("snowflake connection is healthy for " + snowflakeConfig.Name)
-		logger.Info("Snowflake client created and connection validated ...")
 	}
 
-	ingestionBucket = config.Spec.UnstructuredDataProcessingConfig.IngestionBucket
-	dataStorageBucket = config.Spec.UnstructuredDataProcessingConfig.DataStorageBucket
-	cacheDirectory = config.Spec.UnstructuredDataProcessingConfig.CacheDirectory
-
-	logger.Info(fmt.Sprintf("Ingestion bucket: %s, Data storage bucket: %s, Cache directory: %s",
-		ingestionBucket, dataStorageBucket, cacheDirectory))
-
-	doclingServeURL := config.Spec.UnstructuredDataProcessingConfig.DoclingServeURL
-
-	doclingConfig := &docling.ClientConfig{
-		URL:                   doclingServeURL,
-		MaxConcurrentRequests: int64(config.Spec.UnstructuredDataProcessingConfig.MaxConcurrentDoclingTasks),
+	// Skip only status update if we've already processed this generation successfully
+	if config.Status.LastAppliedGeneration == config.Generation && config.IsHealthy() {
+		logger.Info("config already reconciled for current generation, skipping status update")
+		return ctrl.Result{}, nil
 	}
-
-	doclingKey := string(unstructuredSecret.Data["DOCLING_USER_KEY"])
-	if doclingKey != "" {
-		doclingConfig.Key = doclingKey
-	}
-
-	// initialize the docling client
-	doclingClient = docling.NewClientFromURL(doclingConfig)
-
-	// initialze langchain client
-	langchainClient = langchain.NewClient(
-		langchain.ClientConfig{
-			MaxConcurrentRequests: int64(config.Spec.UnstructuredDataProcessingConfig.MaxConcurrentLangchainTasks),
-		},
-	)
-
-	cacheDirectory = config.Spec.UnstructuredDataProcessingConfig.CacheDirectory
-	dataStorageBucket = config.Spec.UnstructuredDataProcessingConfig.DataStorageBucket
 
 	// update the status of the Config CR to indicate that it is healthy
 	config.UpdateStatus(nil)

--- a/internal/controller/controllerutils/conflict_retry.go
+++ b/internal/controller/controllerutils/conflict_retry.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerutils
+
+import (
+	"context"
+
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// StatusUpdateWithRetry runs Get -> mutate -> Status().Update with RetryOnConflict.
+// newEmpty must return a new zero value of the object type (e.g. func() client.Object { return &ChunksGenerator{} }).
+// mutate is called with the fetched object so the caller can set status (e.g. SetWaiting(), UpdateStatus(msg, err)).
+func StatusUpdateWithRetry(ctx context.Context, c client.Client, key client.ObjectKey, newEmpty func() client.Object, mutate func(client.Object)) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		obj := newEmpty()
+		if err := c.Get(ctx, key, obj); err != nil {
+			return err
+		}
+		mutate(obj)
+		return c.Status().Update(ctx, obj)
+	})
+}
+
+// RemoveForceReconcileLabelWithRetry gets the latest object, removes the force-reconcile label, and updates with retry.
+func RemoveForceReconcileLabelWithRetry(ctx context.Context, c client.Client, key client.ObjectKey, newEmpty func() client.Object) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		obj := newEmpty()
+		if err := c.Get(ctx, key, obj); err != nil {
+			return err
+		}
+		return RemoveForceReconcileLabel(ctx, c, obj)
+	})
+}
+
+// AddForceReconcileLabelWithRetry gets the latest object, adds the force-reconcile label, and updates with retry.
+func AddForceReconcileLabelWithRetry(ctx context.Context, c client.Client, key client.ObjectKey, newEmpty func() client.Object) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		obj := newEmpty()
+		if err := c.Get(ctx, key, obj); err != nil {
+			return err
+		}
+		return AddForceReconcileLabel(ctx, c, obj)
+	})
+}

--- a/internal/controller/documentprocessor_controller.go
+++ b/internal/controller/documentprocessor_controller.go
@@ -39,8 +39,8 @@ import (
 )
 
 const (
-	DocumentProcessorControllerName = "DocumentProcessor"
 	requeueAfter                    = 15 * time.Second
+	DocumentProcessorControllerName = "DocumentProcessor"
 )
 
 var (
@@ -62,7 +62,7 @@ type DocumentProcessorReconciler struct {
 
 func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("reconciling DocumentProcessor")
+	logger.Info("reconciling", "controller", DocumentProcessorControllerName)
 
 	// NOTE: Config CR health check is commented out as requested
 	// This was the original dependency on config.spec
@@ -110,6 +110,10 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	fs, err := filestore.New(ctx, cacheDirectory, dataStorageBucket)
 	if err != nil {
+		if IsAWSClientNotInitializedError(err) {
+			logger.Info("ControllerConfig has not initialized AWS clients yet, will try again in a bit ...")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
 		logger.Error(err, "failed to create filestore")
 		return r.handleError(ctx, documentProcessorCR, err)
 	}
@@ -183,7 +187,6 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	logger.Info("all jobs are completed, no need to requeue")
 
-	// all done, let's update the status to ready
 	successMessage := fmt.Sprintf("successfully reconciled document processor: %s", documentProcessorCR.Name)
 	documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/internal/controller/sqsconsumer_controller.go
+++ b/internal/controller/sqsconsumer_controller.go
@@ -32,8 +32,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,6 +71,7 @@ type S3EventRecord struct {
 
 func (r *S3EventRecord) validate(ctx context.Context) bool {
 	logger := log.FromContext(ctx)
+	logger.Info("reconciling", "controller", SQSConsumerControllerName)
 
 	// check if the bucket is the ingestion bucket
 	if r.S3.Bucket.Name != ingestionBucket {
@@ -152,11 +151,6 @@ type S3EventObject struct {
 func (r *SQSConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// if isControllerDisabled(SQSConsumerControllerName) {
-	// 	logger.Info("SQSConsumer controller is disabled, skipping reconciliation")
-	// 	return ctrl.Result{}, nil // no error, just skip the reconciliation
-	// }
-
 	// check if config CR is healthy
 	// TODO: Uncomment when Config CR is available
 	// isHealthy, err := IsConfigCRHealthy(ctx, r.Client, req.Namespace)
@@ -177,14 +171,9 @@ func (r *SQSConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	key := client.ObjectKeyFromObject(sqsConsumerCR)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		res := &operatorv1alpha1.SQSConsumer{}
-		if err := r.Get(ctx, key, res); err != nil {
-			return err
-		}
-		res.SetWaiting()
-		return r.Status().Update(ctx, res)
+	sqsConsumerKey := client.ObjectKeyFromObject(sqsConsumerCR)
+	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, sqsConsumerKey, func() client.Object { return &operatorv1alpha1.SQSConsumer{} }, func(obj client.Object) {
+		obj.(*operatorv1alpha1.SQSConsumer).SetWaiting()
 	}); err != nil {
 		logger.Error(err, "failed to update SQSConsumer status")
 		return ctrl.Result{}, err
@@ -192,6 +181,10 @@ func (r *SQSConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	sqsClient, err := awsclienthandler.GetSQSClient()
 	if err != nil {
+		if IsAWSClientNotInitializedError(err) {
+			logger.Info("ControllerConfig has not initialized AWS clients yet, will try again in a bit ...")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
 		return r.handleError(ctx, sqsConsumerCR, err)
 	}
 
@@ -224,21 +217,15 @@ func (r *SQSConsumerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		logger.Info("deleted message from queue", "MessageId", *message.MessageId)
 	}
 
-	if err := controllerutils.RemoveForceReconcileLabel(ctx, r.Client, sqsConsumerCR); err != nil {
+	if err := controllerutils.RemoveForceReconcileLabelWithRetry(ctx, r.Client, sqsConsumerKey, func() client.Object { return &operatorv1alpha1.SQSConsumer{} }); err != nil {
 		logger.Error(err, "error removing the force-reconcile label from the SQSConsumer CR")
 		return ctrl.Result{}, err
 	}
 
-	// reconcile again after some time to check if there are any more messages to read
 	logger.Info("successfully processed all messages, will check again ...")
 	successMessage := "successfully processed all messages, will check again ..."
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		res := &operatorv1alpha1.SQSConsumer{}
-		if err := r.Get(ctx, key, res); err != nil {
-			return err
-		}
-		res.UpdateStatus(successMessage, nil)
-		return r.Status().Update(ctx, res)
+	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, sqsConsumerKey, func() client.Object { return &operatorv1alpha1.SQSConsumer{} }, func(obj client.Object) {
+		obj.(*operatorv1alpha1.SQSConsumer).UpdateStatus(successMessage, nil)
 	}); err != nil {
 		logger.Error(err, "failed to update SQSConsumer status")
 		return ctrl.Result{}, err
@@ -285,17 +272,8 @@ func (r *SQSConsumerReconciler) processMessage(ctx context.Context, message sqst
 		sourceFilePathSplit := strings.Split(objectKey, "/")
 		dataProductName := sourceFilePathSplit[0]
 
-		// now apply a force reconcile label to the unstructured data product
-		unstructuredDataProduct := &operatorv1alpha1.UnstructuredDataProduct{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Namespace: namespace,
-			Name:      dataProductName,
-		}, unstructuredDataProduct); err != nil {
-			logger.Error(err, "failed to get unstructured data product", "key", objectKey)
-			errorList = append(errorList, err)
-			continue
-		}
-		if err := controllerutils.AddForceReconcileLabel(ctx, r.Client, unstructuredDataProduct); err != nil {
+		udpKey := client.ObjectKey{Namespace: namespace, Name: dataProductName}
+		if err := controllerutils.AddForceReconcileLabelWithRetry(ctx, r.Client, udpKey, func() client.Object { return &operatorv1alpha1.UnstructuredDataProduct{} }); err != nil {
 			logger.Error(err, "failed to add force reconcile label", "key", objectKey)
 			errorList = append(errorList, err)
 			continue
@@ -310,17 +288,12 @@ func (r *SQSConsumerReconciler) handleError(ctx context.Context, sqsConsumerCR *
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
-	key := client.ObjectKeyFromObject(sqsConsumerCR)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.SQSConsumer{}
-		if getErr := r.Get(ctx, key, latest); getErr != nil {
-			return getErr
-		}
-		latest.UpdateStatus("", reconcileErr)
-		return r.Status().Update(ctx, latest)
-	}); err != nil {
-		logger.Error(err, "failed to update SQSConsumer status")
-		return ctrl.Result{}, err
+	sqsConsumerKey := client.ObjectKeyFromObject(sqsConsumerCR)
+	if updateErr := controllerutils.StatusUpdateWithRetry(ctx, r.Client, sqsConsumerKey, func() client.Object { return &operatorv1alpha1.SQSConsumer{} }, func(obj client.Object) {
+		obj.(*operatorv1alpha1.SQSConsumer).UpdateStatus("", reconcileErr)
+	}); updateErr != nil {
+		logger.Error(updateErr, "failed to update SQSConsumer status")
+		return ctrl.Result{}, updateErr
 	}
 	return ctrl.Result{}, reconcileErr
 }

--- a/internal/controller/unstructureddataproduct_controller.go
+++ b/internal/controller/unstructureddataproduct_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,13 +37,13 @@ import (
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/unstructured"
 )
 
+const (
+	UnstructuredDataProductControllerName = "UnstructuredDataProduct"
+)
+
 var (
 	cacheDirectory    string
 	dataStorageBucket string
-)
-
-const (
-	UnstructuredDataProductControllerName = "UnstructuredDataProduct"
 )
 
 // UnstructuredDataProductReconciler reconciles a UnstructuredDataProduct object
@@ -59,7 +60,21 @@ type UnstructuredDataProductReconciler struct {
 
 func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("reconciling UnstructuredDataProduct")
+	logger.Info("reconciling", "controller", UnstructuredDataProductControllerName)
+
+	// check if config CR is healthy
+	isHealthy, err := IsConfigCRHealthy(ctx, r.Client, req.Namespace)
+	if err != nil {
+		logger.Error(err, "failed to check if ControllerConfig CR is healthy")
+		return ctrl.Result{}, err
+	}
+
+	if !isHealthy {
+		logger.Info("ControllerConfig CR is not ready yet, will try again in a bit ...")
+		return ctrl.Result{
+			RequeueAfter: 10 * time.Second,
+		}, nil
+	}
 
 	unstructuredDataProductCR := &operatorv1alpha1.UnstructuredDataProduct{}
 	if err := r.Get(ctx, req.NamespacedName, unstructuredDataProductCR); err != nil {
@@ -143,8 +158,16 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 		return r.handleError(ctx, unstructuredDataProductCR, fmt.Errorf("unsupported source type: %s", unstructuredDataProductCR.Spec.SourceConfig.Type))
 	}
 
+	if !IsControllerConfigGlobalsSet(cacheDirectory, dataStorageBucket) {
+		logger.Info("ControllerConfig has not set cacheDirectory/dataStorageBucket yet, will try again in a bit ...")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
 	fs, err := filestore.New(ctx, cacheDirectory, dataStorageBucket)
 	if err != nil {
+		if IsAWSClientNotInitializedError(err) {
+			logger.Info("ControllerConfig has not initialized AWS clients yet, will try again in a bit ...")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
 		logger.Error(err, "failed to create filestore")
 		return r.handleError(ctx, unstructuredDataProductCR, err)
 	}
@@ -238,16 +261,11 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 
 	// all done, let's update the status to ready
 	successMessage := fmt.Sprintf("successfully reconciled unstructured data product: %s", dataProductName)
-	key := client.ObjectKeyFromObject(unstructuredDataProductCR)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		res := &operatorv1alpha1.UnstructuredDataProduct{}
-		if err := r.Get(ctx, key, res); err != nil {
-			return err
-		}
-		res.UpdateStatus(successMessage, nil)
-		return r.Status().Update(ctx, res)
+	unstructuredDataProductKey := client.ObjectKeyFromObject(unstructuredDataProductCR)
+	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, unstructuredDataProductKey, func() client.Object { return &operatorv1alpha1.UnstructuredDataProduct{} }, func(obj client.Object) {
+		obj.(*operatorv1alpha1.UnstructuredDataProduct).UpdateStatus(successMessage, nil)
 	}); err != nil {
-		logger.Error(err, "failed to update UnstructuredDataProduct CR status", "namespace", key.Namespace, "name", key.Name)
+		logger.Error(err, "failed to update UnstructuredDataProduct CR status", "namespace", unstructuredDataProductKey.Namespace, "name", unstructuredDataProductKey.Name)
 		return r.handleError(ctx, unstructuredDataProductCR, err)
 	}
 	logger.Info("successfully updated UnstructuredDataProduct CR status", "status", unstructuredDataProductCR.Status)
@@ -268,17 +286,12 @@ func (r *UnstructuredDataProductReconciler) handleError(ctx context.Context, uns
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
-	key := client.ObjectKeyFromObject(unstructuredDataProductCR)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.UnstructuredDataProduct{}
-		if getErr := r.Get(ctx, key, latest); getErr != nil {
-			return getErr
-		}
-		latest.UpdateStatus("", reconcileErr)
-		return r.Status().Update(ctx, latest)
-	}); err != nil {
-		logger.Error(err, "failed to update UnstructuredDataProduct CR status")
-		return ctrl.Result{}, err
+	unstructuredDataProductKey := client.ObjectKeyFromObject(unstructuredDataProductCR)
+	if updateErr := controllerutils.StatusUpdateWithRetry(ctx, r.Client, unstructuredDataProductKey, func() client.Object { return &operatorv1alpha1.UnstructuredDataProduct{} }, func(obj client.Object) {
+		obj.(*operatorv1alpha1.UnstructuredDataProduct).UpdateStatus("", reconcileErr)
+	}); updateErr != nil {
+		logger.Error(updateErr, "failed to update UnstructuredDataProduct CR status")
+		return ctrl.Result{}, updateErr
 	}
 	return ctrl.Result{}, reconcileErr
 }


### PR DESCRIPTION
-  Move global variable initialization to the top of ControllerConfig
  reconcile to guarantee they are set after pod restarts, before any
  skip logic. Add  error handling for AWS client initialization
  and reusable retry utilities
    
-  Fixes controllers hanging on "ControllerConfig CR is not ready yet"
    after operator restarts.
    
 - Prevents other controllers from waiting indefinitely for ControllerConfig
   to become ready
