### PR TITLE
Add github action workflow for e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,13 +1,22 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches: [main]
+
 jobs:
   test-e2e:
-    name: Run on Ubuntu
+    name: E2E Tests
     runs-on: ubuntu-latest
+    environment: e2e-tests
+    permissions:
+      contents: read
+      packages: read
+
     steps:
       - uses: actions/checkout@v5
         name: checkout the code


### PR DESCRIPTION
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets - Unable to access upstream repo secrets 
- workflow needs to there in the main