### PR TITLE
Move force-reconcile label removal to start

### DIFF
--- a/internal/controller/chunksgenerator_controller.go
+++ b/internal/controller/chunksgenerator_controller.go
@@ -87,6 +87,13 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	chunksGeneratorKey := client.ObjectKeyFromObject(chunksGeneratorCR)
+	if err := controllerutils.RemoveForceReconcileLabelWithRetry(ctx, r.Client, chunksGeneratorKey,
+		func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }); err != nil {
+		logger.Error(err, "error removing the force-reconcile label from the ChunksGenerator CR")
+		return ctrl.Result{}, err
+	}
+
 	// set status to waiting
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest := &operatorv1alpha1.ChunksGenerator{}
@@ -116,18 +123,6 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	filePaths, err := r.fileStore.ListFilesInPath(ctx, dataProductName)
 	if err != nil {
 		logger.Error(err, "failed to list files in path")
-		return r.handleError(ctx, chunksGeneratorCR, err)
-	}
-
-	// now that we have the list of files to process, we may remove the force reconcile label as we are ready to accept more events
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.ChunksGenerator{}
-		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-			return err
-		}
-		return controllerutils.RemoveForceReconcileLabel(ctx, r.Client, latest)
-	}); err != nil {
-		logger.Error(err, "failed to remove force reconcile label")
 		return r.handleError(ctx, chunksGeneratorCR, err)
 	}
 
@@ -187,7 +182,6 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		logger.Info("no files were chunked, no need to add force reconcile label to UnstructuredDataProduct CR")
 	}
 
-	chunksGeneratorKey := client.ObjectKeyFromObject(chunksGeneratorCR)
 	successMessage := fmt.Sprintf("successfully reconciled chunks generator: %s", chunksGeneratorCR.Name)
 	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, chunksGeneratorKey, func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }, func(obj client.Object) {
 		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus(successMessage, nil)

--- a/internal/controller/documentprocessor_controller.go
+++ b/internal/controller/documentprocessor_controller.go
@@ -84,6 +84,13 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
+	documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
+	if err := controllerutils.RemoveForceReconcileLabelWithRetry(ctx, r.Client, documentProcessorKey,
+		func() client.Object { return &operatorv1alpha1.DocumentProcessor{} }); err != nil {
+		logger.Error(err, "error removing the force-reconcile label from the DocumentProcessor CR")
+		return ctrl.Result{}, err
+	}
+
 	// set status to waiting
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest := &operatorv1alpha1.DocumentProcessor{}
@@ -137,18 +144,6 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return r.handleError(ctx, documentProcessorCR, err)
 	}
 
-	// now that we have the list of files to process, we may remove the force reconcile label as we are ready to accept more events
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.DocumentProcessor{}
-		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-			return err
-		}
-		return controllerutils.RemoveForceReconcileLabel(ctx, r.Client, latest)
-	}); err != nil {
-		logger.Error(err, "failed to remove force reconcile label from DocumentProcessor CR")
-		return r.handleError(ctx, documentProcessorCR, err)
-	}
-
 	documentProcessingErrors := []error{}
 	rawFilePaths := unstructured.FilterRawFilePaths(filePaths)
 	for _, rawFilePath := range rawFilePaths {
@@ -192,7 +187,6 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	logger.Info("all jobs are completed, no need to requeue")
 
 	successMessage := fmt.Sprintf("successfully reconciled document processor: %s", latestDocumentProcessorCR.Name)
-	documentProcessorKey := client.ObjectKeyFromObject(latestDocumentProcessorCR)
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		res := &operatorv1alpha1.DocumentProcessor{}
 		if err := r.Get(ctx, documentProcessorKey, res); err != nil {

--- a/internal/controller/unstructureddataproduct_controller.go
+++ b/internal/controller/unstructureddataproduct_controller.go
@@ -84,6 +84,13 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 	}
 	dataProductName := unstructuredDataProductCR.Name
 
+	unstructuredDataProductKey := client.ObjectKeyFromObject(unstructuredDataProductCR)
+	if err := controllerutils.RemoveForceReconcileLabelWithRetry(ctx, r.Client, unstructuredDataProductKey,
+		func() client.Object { return &operatorv1alpha1.UnstructuredDataProduct{} }); err != nil {
+		logger.Error(err, "error removing the force-reconcile label from the UnstructuredDataProduct CR")
+		return ctrl.Result{}, err
+	}
+
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest := &operatorv1alpha1.UnstructuredDataProduct{}
 		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
@@ -195,18 +202,6 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 	}
 	logger.Info("successfully stored files to filestore", "files", storedFiles)
 
-	// // now we may remove the force reconcile label as we have read all the files from the source and we are ready to accept more events
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.UnstructuredDataProduct{}
-		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-			return err
-		}
-		return controllerutils.RemoveForceReconcileLabel(ctx, r.Client, latest)
-	}); err != nil {
-		logger.Error(err, "failed to remove force reconcile label from UnstructuredDataProduct CR")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
-	}
-
 	// add force reconcile label to the DocumentProcessor CR
 	documentProcessorKey := client.ObjectKey{
 		Namespace: unstructuredDataProductCR.Namespace,
@@ -267,7 +262,6 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 
 	// all done, let's update the status to ready
 	successMessage := fmt.Sprintf("successfully reconciled unstructured data product: %s", dataProductName)
-	unstructuredDataProductKey := client.ObjectKeyFromObject(unstructuredDataProductCR)
 	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, unstructuredDataProductKey, func() client.Object { return &operatorv1alpha1.UnstructuredDataProduct{} }, func(obj client.Object) {
 		obj.(*operatorv1alpha1.UnstructuredDataProduct).UpdateStatus(successMessage, nil)
 	}); err != nil {


### PR DESCRIPTION
This will move force-reconcile label cleanup for every CR to start of the controller