### PR TITLE
Fix: Embeddings file deletion from filestore

### DIFF
--- a/pkg/unstructured/source.go
+++ b/pkg/unstructured/source.go
@@ -115,6 +115,13 @@ func (s *S3BucketSource) SyncFilesToFilestore(ctx context.Context, fs *filestore
 					errorList[localFilePath] = err
 					continue
 				}
+				err = fs.Delete(ctx, GetVectorEmbeddingsFilePath(localFilePath))
+				if err != nil {
+					logger.Error(err, "failed to delete vector embeddings file from filestore",
+						"file", GetVectorEmbeddingsFilePath(localFilePath))
+					errorList[localFilePath] = err
+					continue
+				}
 				logger.Info("successfully deleted file and associated files from the filestore", "file", localFilePath)
 			}
 		}


### PR DESCRIPTION
When the file is deleted from upstream ingestion bucket so its all the associated files 

-  -metadata.json
-  -converted.json
-  -chunks.json
-  -embeddings.json 
should be deleted from the filestore