### PR TITLE
fix: Github workflow CI build-action

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -53,7 +53,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=ref,event=branch,enable=${{ startsWith(github.ref, 'refs/heads/release-') }}
             type=ref,event=pr
             type=ref,event=tag


### PR DESCRIPTION
- Removed latest tag is getting pushed on pr requests