### PR TITLE
Generate deploy manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.1
 
+OUTPUT_FILE ?= manifest.yaml
+DEPLOYMENT_NAMESPACE ?= unstructured-controller-namespace
+SUFFIX ?= "-test"
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -213,12 +217,17 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	cd config/deploy && $(KUSTOMIZE) edit set image controller=${IMG} && $(KUSTOMIZE) edit set namespace "${DEPLOYMENT_NAMESPACE}" && $(KUSTOMIZE) edit set namesuffix -- "${SUFFIX}"
+	$(KUSTOMIZE) build config/deploy | $(KUBECTL) apply -f -
+
+.PHONY: generate-deploy-manifests
+generate-deploy-manifests: manifests kustomize
+	cd config/deploy && $(KUSTOMIZE) edit set image controller=${IMG} && $(KUSTOMIZE) edit set namespace "${DEPLOYMENT_NAMESPACE}" && $(KUSTOMIZE) edit set namesuffix -- "${SUFFIX}"
+	$(KUSTOMIZE) build config/deploy -o ${OUTPUT_FILE}
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/deploy | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Dependencies
 

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -1,0 +1,16 @@
+nameSuffix: -test
+
+namePrefix: unstructured-
+
+namespace: unstructured-controller-namespace
+
+resources:
+- ../rbac
+- ../manager
+
+images:
+- name: controller
+  newName: ghcr.io/redhat-data-and-ai/unstructured-data-controller
+  newTag: latest
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,12 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    app.kubernetes.io/name: unstructured-data-controller
-    app.kubernetes.io/managed-by: kustomize
-  name: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -104,6 +95,6 @@ spec:
       volumes:
       - name: unstructured-datastore-cache-storage
         persistentVolumeClaim:
-          claimName: unstructured-datastore-cache
+          claimName: datastore-cache
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manager/pvc.yaml
+++ b/config/manager/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: unstructured-datastore-cache
+  name: datastore-cache
 spec:
   accessModes:
     - ReadWriteOncePod

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -15,9 +15,9 @@ resources:
 # can access the metrics endpoint. Comment the following
 # permissions if you want to disable this protection.
 # More info: https://book.kubebuilder.io/reference/metrics.html
-- metrics_auth_role.yaml
-- metrics_auth_role_binding.yaml
-- metrics_reader_role.yaml
+# - metrics_auth_role.yaml
+# - metrics_auth_role_binding.yaml
+# - metrics_reader_role.yaml
 # For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
 # not used by the unstructured-data-controller itself. You can comment the following lines

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -49,7 +49,7 @@ var (
 
 const (
 	testNamespace          = "unstructured-controller-namespace"
-	deploymentName         = "unstructured-controller-manager"
+	deploymentName         = "unstructured-controller-manager-test"
 	unstructuredSecretName = "unstructured-secret"
 )
 
@@ -127,6 +127,13 @@ func testSetup(_ context.Context, runningProcesses *[]exec.Cmd, config *envconf.
 	image := os.Getenv("IMG")
 	if image == "" {
 		return fmt.Errorf("IMG environment variable is required")
+	}
+
+	log.Println("Install CRDs ...")
+	installCRDCommand := "make install"
+	if p := utils.RunCommand(installCRDCommand); p.Err() != nil {
+		log.Printf("Failed to install CRDs: %s", p.Err())
+		return p.Err()
 	}
 
 	log.Println("Deploying operator with CRDs installed...")
@@ -307,6 +314,7 @@ func testCleanup(_ context.Context, _ *envconf.Config, runningProcesses *[]exec.
 		fmt.Sprintf("kubectl delete -f test/localstack/ -n %s --ignore-not-found=true", testNamespace),
 		fmt.Sprintf("kubectl delete -f test/docling-serve/ -n %s --ignore-not-found=true", testNamespace),
 		fmt.Sprintf("kubectl delete -f test/ollama-embedding/ -n %s --ignore-not-found=true", testNamespace),
+		"make uninstall",
 	}
 	for _, command := range commandList {
 		if p := utils.RunCommand(command); p.Err() != nil {


### PR DESCRIPTION
this will have make generate-deploy-manifests
target in makefile to generate the manifests
based on image, namespace and suffix provided