### PR TITLE
Add dynamic stage creation in snowflake for e2e tests CI Jobs

### DIFF
--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -83,3 +83,23 @@ func (c *Client) ExecuteQueryWithRole(ctx context.Context, warehouse, query, rol
 	err := c.execute(ctx, query, role)
 	return err
 }
+
+func (c *Client) CreateSnowflakeStage(ctx context.Context, warehouse, role,
+	dbName, schemaName, stageName string) error {
+	createStageQuery := fmt.Sprintf(
+		"CREATE STAGE IF NOT EXISTS %s.%s.%s FILE_FORMAT = (TYPE = 'JSON')", dbName, schemaName, stageName)
+	if err := c.useWarehouse(ctx, role, warehouse); err != nil {
+		return err
+	}
+	err := c.execute(ctx, createStageQuery, role)
+	return err
+}
+
+func (c *Client) DropSnowflakeStage(ctx context.Context, warehouse, role, dbName, schemaName, stageName string) error {
+	dropStageQuery := fmt.Sprintf("DROP STAGE IF EXISTS %s.%s.%s", dbName, schemaName, stageName)
+	if err := c.useWarehouse(ctx, role, warehouse); err != nil {
+		return err
+	}
+	err := c.execute(ctx, dropStageQuery, role)
+	return err
+}

--- a/test/e2e/unstructured_test.go
+++ b/test/e2e/unstructured_test.go
@@ -52,6 +52,8 @@ import (
 func TestUnstructuredDataLoad(t *testing.T) {
 	feature := features.New("Unstructured Data Load")
 
+	// generate a unique string
+	uniqueTestString := operatorUtils.RandomStringGenerator(10)
 	unstructuredBucketName := "unstructured-bucket"
 	unstructuredDataStorageBucketName := "data-storage-bucket"
 	unstructuredQueueName := "unstructured-queue"
@@ -59,7 +61,7 @@ func TestUnstructuredDataLoad(t *testing.T) {
 	operatorControllerConfig := operatorUtils.GetControllerConfigResource()
 	databaseName := "unstructured_db"
 	schemaName := "unstructured"
-	internalStageName := schemaName + "_internal_stg"
+	internalStageName := fmt.Sprintf("%s_internal_stg_%s", schemaName, uniqueTestString)
 	dataProductCRName := schemaName
 
 	queueURL := "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/" + unstructuredQueueName
@@ -181,8 +183,23 @@ func TestUnstructuredDataLoad(t *testing.T) {
 				t.Error(err)
 			}
 
-			// create unstructured data product CR
-			unstructuredDataProduct := operatorUtils.GetUnstructuredDataProductResource(dataProductCRName, testNamespace)
+			// create internal stage in Snowflake with JSON file format
+			if err := sfClient.CreateSnowflakeStage(ctx, operatorControllerConfig.Spec.SnowflakeConfig.Warehouse, operatorControllerConfig.Spec.SnowflakeConfig.Role, databaseName, schemaName, internalStageName); err != nil {
+				t.Fatalf("Failed to create internal stage: %s", err)
+			}
+			t.Logf("created internal stage: %s", internalStageName)
+
+			// register cleanup function to ensure stage is dropped even if test fails with t.Fatal()
+			t.Cleanup(func() {
+				if err := sfClient.DropSnowflakeStage(ctx, operatorControllerConfig.Spec.SnowflakeConfig.Warehouse, operatorControllerConfig.Spec.SnowflakeConfig.Role, databaseName, schemaName, internalStageName); err != nil {
+					t.Logf("Warning: failed to drop stage in cleanup: %v", err)
+				} else {
+					t.Logf("Successfully dropped stage in cleanup: %s", internalStageName)
+				}
+			})
+
+			// create unstructured data product CR with unique stage name
+			unstructuredDataProduct := operatorUtils.GetUnstructuredDataProductResourceWithStage(dataProductCRName, testNamespace, internalStageName)
 
 			t.Log("create unstructured dataproduct CR ...")
 			if err := kubeClient.Resources(testNamespace).Create(ctx, &unstructuredDataProduct); err != nil {
@@ -746,13 +763,6 @@ func TestUnstructuredDataLoad(t *testing.T) {
 			if err := kubeClient.Resources(testNamespace).Delete(ctx, unstructuredDataProduct); err != nil {
 				t.Fatal(err)
 			}
-
-			// execute query to remove all the files from the stage
-			removeFilesQuery := fmt.Sprintf("REMOVE '@%s.%s.%s'", databaseName, schemaName, internalStageName)
-			if err := sfClient.ExecuteQueryWithRole(ctx, operatorControllerConfig.Spec.SnowflakeConfig.Warehouse, removeFilesQuery, operatorControllerConfig.Spec.SnowflakeConfig.Role); err != nil {
-				t.Error(err)
-			}
-
 			return ctx
 		},
 	)

--- a/test/utils/utils_function.go
+++ b/test/utils/utils_function.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 
 	"github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
@@ -10,7 +11,19 @@ import (
 )
 
 // DefaultE2ENamespace is the namespace used by e2e tests (must match test/e2e/main_test.go testNamespace).
-const DefaultE2ENamespace = "unstructured-controller-namespace"
+const (
+	DefaultE2ENamespace = "unstructured-controller-namespace"
+)
+
+// RandomStringGenerator will return a random string of provided length
+func RandomStringGenerator(length int) string {
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
 
 func GetControllerConfigResource() *v1alpha1.ControllerConfig {
 	account := os.Getenv("SNOWFLAKE_ACCOUNT")
@@ -60,13 +73,16 @@ func GetControllerConfigResource() *v1alpha1.ControllerConfig {
 	}
 }
 
-// create an UnstructuredDataProduct CR for e2e tests
-func GetUnstructuredDataProductResource(name, namespace string) v1alpha1.UnstructuredDataProduct {
+// GetUnstructuredDataProductResourceWithStage creates an UnstructuredDataProduct CR for e2e tests
+func GetUnstructuredDataProductResourceWithStage(name, namespace, stageName string) v1alpha1.UnstructuredDataProduct {
 	if name == "" {
 		name = "unstructured"
 	}
 	if namespace == "" {
 		namespace = DefaultE2ENamespace
+	}
+	if stageName == "" {
+		stageName = "unstructured_internal_stg"
 	}
 	return v1alpha1.UnstructuredDataProduct{
 		ObjectMeta: metav1.ObjectMeta{
@@ -90,7 +106,7 @@ func GetUnstructuredDataProductResource(name, namespace string) v1alpha1.Unstruc
 				SnowflakeInternalStageConfig: v1alpha1.SnowflakeInternalStageConfig{
 					Database: "unstructured_db",
 					Schema:   "unstructured",
-					Stage:    "unstructured_internal_stg",
+					Stage:    stageName,
 				},
 			},
 			DocumentProcessorConfig: v1alpha1.DocumentProcessorConfig{


### PR DESCRIPTION
- previously when 2 CI's are running simultaneously, they are causing concurrency issues
- Now for every CI job , there is separate stage using UUID
- Fallback to current time if testing locally