### PR TITLE
Add health endpoint Service and Route for external monitoring

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - manager.yaml
 - pvc.yaml
+- service.yaml

--- a/config/manager/service.yaml
+++ b/config/manager/service.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: unstructured-data-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-service
+spec:
+  ports:
+  - name: https
+    protocol: TCP
+    port: 8081
+    targetPort: 8081
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: unstructured-data-controller


### PR DESCRIPTION
Enables external health monitoring to allow endpoint monitoring via Gatus.