### PR TITLE
Enable linter for logger

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - govet
     - ineffassign
     - lll
+    - loggercheck
     - misspell
     - nakedret
     - nilerr
@@ -30,6 +31,9 @@ linters:
     - unused
     - whitespace
   settings:
+    loggercheck:
+      require-string-key: true
+      no-printf-like: true
     staticcheck:
       dot-import-whitelist:
         - github.com/onsi/ginkgo/v2

--- a/pkg/unstructured/destination.go
+++ b/pkg/unstructured/destination.go
@@ -137,6 +137,7 @@ func (d *SnowflakeInternalStage) SyncFilesToDestination(ctx context.Context,
 		if len(fileRows) == 0 {
 			logger.Error(fmt.Errorf("no file rows returned while uploading file to snowflake internal stage: %s",
 				embeddingsFileInFilestore.ConvertedDocument.Metadata.RawFilePath),
+				"no file rows returned",
 				"file", embeddingsFileInFilestore.ConvertedDocument.Metadata.RawFilePath)
 			errorList = append(errorList,
 				fmt.Errorf("no file rows returned while uploading file to snowflake internal stage: %s",


### PR DESCRIPTION
This is to enable linter for logger.error
as it does not fail at build if there are
less number of arguments