### PR TITLE
Replace force-reconcile labels with Watches, Owns and status predicates

### DIFF
--- a/api/v1alpha1/chunksgenerator_types.go
+++ b/api/v1alpha1/chunksgenerator_types.go
@@ -34,6 +34,7 @@ type ChunksGeneratorSpec struct {
 type ChunksGeneratorStatus struct {
 	LastAppliedGeneration int64              `json:"lastAppliedGeneration,omitempty"`
 	Conditions            []metav1.Condition `json:"conditions,omitempty"`
+	IsNewFilesChunked     bool               `json:"isNewFilesChunked,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -67,6 +68,7 @@ func (c *ChunksGenerator) SetWaiting() {
 		Message:            "ChunksGenerator is getting reconciled",
 		Reason:             "Waiting",
 	}
+	c.Status.IsNewFilesChunked = false
 	for i, currentCondition := range c.Status.Conditions {
 		if currentCondition.Type == condition.Type {
 			c.Status.Conditions[i] = condition
@@ -76,11 +78,12 @@ func (c *ChunksGenerator) SetWaiting() {
 	c.Status.Conditions = append(c.Status.Conditions, condition)
 }
 
-func (c *ChunksGenerator) UpdateStatus(message string, err error) {
+func (c *ChunksGenerator) UpdateStatus(message string, err error, isNewFileChunked bool) {
 	condition := metav1.Condition{
 		Type:               ChunksGeneratorCondition,
 		LastTransitionTime: metav1.Now(),
 	}
+	c.Status.IsNewFilesChunked = isNewFileChunked
 	if err == nil {
 		condition.Status = metav1.ConditionTrue
 		condition.Message = message

--- a/api/v1alpha1/documentprocessor_types.go
+++ b/api/v1alpha1/documentprocessor_types.go
@@ -38,6 +38,7 @@ type DocumentProcessorStatus struct {
 	Conditions              []metav1.Condition `json:"conditions,omitempty"`
 	Jobs                    []Job              `json:"jobs,omitempty"`
 	PermanentlyFailingFiles []string           `json:"permanentlyFailingFiles,omitempty"`
+	IsNewFilesProcessed     bool               `json:"isNewFilesProcessed,omitempty"`
 }
 
 type Job struct {
@@ -81,6 +82,7 @@ func (d *DocumentProcessor) SetWaiting() {
 		Message:            "DocumentProcessor is getting reconciled",
 		Reason:             "Waiting",
 	}
+	d.Status.IsNewFilesProcessed = false
 	for i, currentCondition := range d.Status.Conditions {
 		if currentCondition.Type == condition.Type {
 			d.Status.Conditions[i] = condition
@@ -130,12 +132,12 @@ func (d *DocumentProcessor) IsFilePermanentlyFailing(filePath string) bool {
 	return slices.Contains(d.Status.PermanentlyFailingFiles, filePath)
 }
 
-func (d *DocumentProcessor) UpdateStatus(message string, err error) {
+func (d *DocumentProcessor) UpdateStatus(message string, err error, isNewFileProcessed bool) {
 	condition := metav1.Condition{
 		Type:               DocumentProcessorCondition,
 		LastTransitionTime: metav1.Now(),
 	}
-
+	d.Status.IsNewFilesProcessed = isNewFileProcessed
 	if err == nil {
 		condition.Status = metav1.ConditionTrue
 		condition.Message = message

--- a/api/v1alpha1/unstructureddataproduct_types.go
+++ b/api/v1alpha1/unstructureddataproduct_types.go
@@ -133,6 +133,7 @@ type SnowflakeInternalStageConfig struct {
 type UnstructuredDataProductStatus struct {
 	LastAppliedGeneration int64              `json:"lastAppliedGeneration,omitempty"`
 	Conditions            []metav1.Condition `json:"conditions,omitempty"`
+	IsNewFilesDetected    bool               `json:"isNewFilesDetected,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -166,6 +167,7 @@ func (u *UnstructuredDataProduct) SetWaiting() {
 		Message:            "UnstructuredDataProduct is getting reconciled",
 		Reason:             "Waiting",
 	}
+	u.Status.IsNewFilesDetected = false
 	for i, currentCondition := range u.Status.Conditions {
 		if currentCondition.Type == condition.Type {
 			u.Status.Conditions[i] = condition
@@ -175,11 +177,12 @@ func (u *UnstructuredDataProduct) SetWaiting() {
 	u.Status.Conditions = append(u.Status.Conditions, condition)
 }
 
-func (u *UnstructuredDataProduct) UpdateStatus(message string, err error) {
+func (u *UnstructuredDataProduct) UpdateStatus(message string, err error, isNewFileDetected bool) {
 	condition := metav1.Condition{
 		Type:               UnstructuredDataProductCondition,
 		LastTransitionTime: metav1.Now(),
 	}
+	u.Status.IsNewFilesDetected = isNewFileDetected
 	if err == nil {
 		condition.Status = metav1.ConditionTrue
 		condition.Message = message

--- a/api/v1alpha1/vectorembeddingsgenerator_types.go
+++ b/api/v1alpha1/vectorembeddingsgenerator_types.go
@@ -36,6 +36,7 @@ type VectorEmbeddingsGeneratorSpec struct {
 type VectorEmbeddingsGeneratorStatus struct {
 	LastAppliedGeneration int64              `json:"lastAppliedGeneration,omitempty"`
 	Conditions            []metav1.Condition `json:"conditions,omitempty"`
+	IsNewFilesEmbedded    bool               `json:"isNewFilesEmbedded,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -69,6 +70,7 @@ func (c *VectorEmbeddingsGenerator) SetWaiting() {
 		Message:            "VectorEmbeddingsGenerator is getting reconciled",
 		Reason:             "Waiting",
 	}
+	c.Status.IsNewFilesEmbedded = false
 	for i, currentCondition := range c.Status.Conditions {
 		if currentCondition.Type == condition.Type {
 			c.Status.Conditions[i] = condition
@@ -78,7 +80,7 @@ func (c *VectorEmbeddingsGenerator) SetWaiting() {
 	c.Status.Conditions = append(c.Status.Conditions, condition)
 }
 
-func (c *VectorEmbeddingsGenerator) UpdateStatus(message string, err error) {
+func (c *VectorEmbeddingsGenerator) UpdateStatus(message string, err error, isEmbedded bool) {
 	condition := metav1.Condition{
 		Type:               VectorEmbeddingGenerationConditionType,
 		LastTransitionTime: metav1.Now(),
@@ -93,6 +95,7 @@ func (c *VectorEmbeddingsGenerator) UpdateStatus(message string, err error) {
 		condition.Message = message + ", error: " + err.Error()
 		condition.Reason = ReconcileFailed
 	}
+	c.Status.IsNewFilesEmbedded = isEmbedded
 
 	for i, currentCondition := range c.Status.Conditions {
 		if currentCondition.Type == condition.Type {

--- a/config/crd/bases/operator.dataverse.redhat.com_chunksgenerators.yaml
+++ b/config/crd/bases/operator.dataverse.redhat.com_chunksgenerators.yaml
@@ -162,6 +162,8 @@ spec:
                   - type
                   type: object
                 type: array
+              isNewFilesChunked:
+                type: boolean
               lastAppliedGeneration:
                 format: int64
                 type: integer

--- a/config/crd/bases/operator.dataverse.redhat.com_documentprocessors.yaml
+++ b/config/crd/bases/operator.dataverse.redhat.com_documentprocessors.yaml
@@ -142,6 +142,8 @@ spec:
                   - type
                   type: object
                 type: array
+              isNewFilesProcessed:
+                type: boolean
               jobs:
                 items:
                   properties:

--- a/config/crd/bases/operator.dataverse.redhat.com_unstructureddataproducts.yaml
+++ b/config/crd/bases/operator.dataverse.redhat.com_unstructureddataproducts.yaml
@@ -252,6 +252,8 @@ spec:
                   - type
                   type: object
                 type: array
+              isNewFilesDetected:
+                type: boolean
               lastAppliedGeneration:
                 format: int64
                 type: integer

--- a/config/crd/bases/operator.dataverse.redhat.com_vectorembeddingsgenerators.yaml
+++ b/config/crd/bases/operator.dataverse.redhat.com_vectorembeddingsgenerators.yaml
@@ -121,6 +121,8 @@ spec:
                   - type
                   type: object
                 type: array
+              isNewFilesEmbedded:
+                type: boolean
               lastAppliedGeneration:
                 format: int64
                 type: integer

--- a/internal/controller/chunksgenerator_controller.go
+++ b/internal/controller/chunksgenerator_controller.go
@@ -23,12 +23,17 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/internal/controller/controllerutils"
@@ -83,16 +88,34 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	chunksGeneratorCR := &operatorv1alpha1.ChunksGenerator{}
 	if err := r.Get(ctx, req.NamespacedName, chunksGeneratorCR); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			logger.Info("ChunksGenerator CR not found, may have been deleted or not yet created")
+			return ctrl.Result{}, nil
+		}
 		logger.Error(err, "failed to get ChunksGenerator CR")
 		return ctrl.Result{}, err
 	}
+	isNewFileChunked := false
+
+	// Only do early-exit checks if this CR already has status initialized to ensure initial status set
+	if len(chunksGeneratorCR.Status.Conditions) > 0 {
+		documentProcessorkey := client.ObjectKey{Namespace: chunksGeneratorCR.Namespace, Name: chunksGeneratorCR.Spec.DataProduct}
+		documentProcessorCR := &operatorv1alpha1.DocumentProcessor{}
+		err = r.Get(ctx, documentProcessorkey, documentProcessorCR)
+		if err == nil {
+			logger.Info("successfully got DocumentProcessor CR", "namespace", documentProcessorCR.Namespace, "name", documentProcessorCR.Name)
+			for _, condition := range documentProcessorCR.Status.Conditions {
+				if (condition.Type == operatorv1alpha1.DocumentProcessorCondition && condition.Status == metav1.ConditionUnknown) ||
+					(condition.Type == operatorv1alpha1.DocumentProcessorCondition && condition.Status == metav1.ConditionTrue && !documentProcessorCR.Status.IsNewFilesProcessed) ||
+					(condition.Type == operatorv1alpha1.DocumentProcessorCondition && condition.Status == metav1.ConditionFalse) {
+					logger.Info("This event is triggered because of watches on DocumentProcessor CR and its status is either waiting or no new files processed so do early exit to avoid duplicate processing", "namespace", documentProcessorCR.Namespace, "name", documentProcessorCR.Name)
+					return ctrl.Result{}, nil
+				}
+			}
+		}
+	}
 
 	chunksGeneratorKey := client.ObjectKeyFromObject(chunksGeneratorCR)
-	if err := controllerutils.RemoveForceReconcileLabelWithRetry(ctx, r.Client, chunksGeneratorKey,
-		func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }); err != nil {
-		logger.Error(err, "error removing the force-reconcile label from the ChunksGenerator CR")
-		return ctrl.Result{}, err
-	}
 
 	// set status to waiting
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -114,7 +137,7 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		logger.Error(err, "failed to create filestore")
-		return r.handleError(ctx, chunksGeneratorCR, err)
+		return r.handleError(ctx, chunksGeneratorCR, err, isNewFileChunked)
 	}
 	r.fileStore = fs
 
@@ -123,7 +146,7 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	filePaths, err := r.fileStore.ListFilesInPath(ctx, dataProductName)
 	if err != nil {
 		logger.Error(err, "failed to list files in path")
-		return r.handleError(ctx, chunksGeneratorCR, err)
+		return r.handleError(ctx, chunksGeneratorCR, err, isNewFileChunked)
 	}
 
 	chunkingErrors := []error{}
@@ -133,7 +156,7 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	for _, convertedFilePath := range convertedFilePaths {
 		logger.Info("processing converted file", "file", convertedFilePath)
-		_, err := r.processConvertedFile(ctx, convertedFilePath, chunksGeneratorCR)
+		isChunked, err := r.processConvertedFile(ctx, convertedFilePath, chunksGeneratorCR)
 		if err != nil {
 			if strings.Contains(err.Error(), langchain.SemaphoreAcquireError) {
 				logger.Error(err, "failed to process converted file, semaphore acquire error, will try again later", "file", convertedFilePath)
@@ -145,12 +168,15 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			continue
 		}
 		logger.Info("successfully processed converted file", "file", convertedFilePath)
+		if isChunked {
+			isNewFileChunked = true
+		}
 	}
 
 	if len(chunkingErrors) > 0 {
 		err := fmt.Errorf("failed to chunk some files: %v", chunkingErrors)
 		logger.Error(err, "chunking error")
-		return r.handleError(ctx, chunksGeneratorCR, err)
+		return r.handleError(ctx, chunksGeneratorCR, err, isNewFileChunked)
 	}
 
 	if len(skippedFiles) > 0 {
@@ -160,25 +186,12 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}, nil
 	}
 
-	// Add force reconcile to VectorEmbeddingsGenerator CR
-	vectorEmbeddingsGeneratorKey := client.ObjectKey{Namespace: chunksGeneratorCR.Namespace, Name: chunksGeneratorCR.Spec.DataProduct}
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		vectorEmbeddingsGeneratorCR := &operatorv1alpha1.VectorEmbeddingsGenerator{}
-		if err := r.Get(ctx, vectorEmbeddingsGeneratorKey, vectorEmbeddingsGeneratorCR); err != nil {
-			return err
-		}
-		return controllerutils.AddForceReconcileLabel(ctx, r.Client, vectorEmbeddingsGeneratorCR)
-	}); err != nil {
-		logger.Error(err, "failed to add force reconcile label to VectorEmbeddingsGenerator CR")
-		return r.handleError(ctx, chunksGeneratorCR, err)
-	}
-
 	successMessage := fmt.Sprintf("successfully reconciled chunks generator: %s", chunksGeneratorCR.Name)
 	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, chunksGeneratorKey, func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus(successMessage, nil)
+		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus(successMessage, nil, isNewFileChunked)
 	}); err != nil {
 		logger.Error(err, "failed to update ChunksGenerator CR status", "namespace", chunksGeneratorKey.Namespace, "name", chunksGeneratorKey.Name)
-		return r.handleError(ctx, chunksGeneratorCR, err)
+		return r.handleError(ctx, chunksGeneratorCR, err, isNewFileChunked)
 	}
 	logger.Info("successfully updated ChunksGenerator CR status", "status", chunksGeneratorCR.Status)
 
@@ -359,19 +372,29 @@ func (r *ChunksGeneratorReconciler) chunkFile(ctx context.Context, convertedFile
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ChunksGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	labelPredicate := controllerutils.ForceReconcilePredicate()
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1alpha1.ChunksGenerator{}).
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, labelPredicate)).
+		For(&operatorv1alpha1.ChunksGenerator{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&operatorv1alpha1.DocumentProcessor{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+				return []reconcile.Request{{
+					NamespacedName: types.NamespacedName{
+						Name:      obj.GetName(),
+						Namespace: obj.GetNamespace(),
+					},
+				}}
+			}),
+			builder.WithPredicates(controllerutils.NewFilesProcessedPredicate()),
+		).
 		Complete(r)
 }
-func (r *ChunksGeneratorReconciler) handleError(ctx context.Context, chunksGeneratorCR *operatorv1alpha1.ChunksGenerator, err error) (ctrl.Result, error) {
+func (r *ChunksGeneratorReconciler) handleError(ctx context.Context, chunksGeneratorCR *operatorv1alpha1.ChunksGenerator, err error, isNewFileChunked bool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
 	chunksGeneratorKey := client.ObjectKeyFromObject(chunksGeneratorCR)
 	if updateErr := controllerutils.StatusUpdateWithRetry(ctx, r.Client, chunksGeneratorKey, func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus("", reconcileErr)
+		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus("", reconcileErr, isNewFileChunked)
 	}); updateErr != nil {
 		logger.Error(updateErr, "failed to update ChunksGenerator CR status")
 		return ctrl.Result{}, updateErr

--- a/internal/controller/controllerutils/force_reconcile.go
+++ b/internal/controller/controllerutils/force_reconcile.go
@@ -87,3 +87,12 @@ func AddForceReconcileLabel(ctx context.Context, c client.Client, obj client.Obj
 	obj.SetLabels(labels)
 	return c.Update(ctx, obj)
 }
+
+func HasForceReconcileLabel(obj client.Object) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	_, ok := labels[ForceReconcileLabel]
+	return ok
+}

--- a/internal/controller/controllerutils/status_field_predicate.go
+++ b/internal/controller/controllerutils/status_field_predicate.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerutils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
+)
+
+func NewFilesDetectedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+
+			oldUDP, oldOk := e.ObjectOld.(*operatorv1alpha1.UnstructuredDataProduct)
+			newUDP, newOk := e.ObjectNew.(*operatorv1alpha1.UnstructuredDataProduct)
+
+			if oldOk && newOk {
+				if oldUDP.Status.IsNewFilesDetected != newUDP.Status.IsNewFilesDetected {
+					return true
+				}
+			}
+			return false
+		},
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return true
+		},
+	}
+}
+
+func NewFilesProcessedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+
+			oldDP, oldOk := e.ObjectOld.(*operatorv1alpha1.DocumentProcessor)
+			newDP, newOk := e.ObjectNew.(*operatorv1alpha1.DocumentProcessor)
+
+			if oldOk && newOk {
+				if oldDP.Status.IsNewFilesProcessed != newDP.Status.IsNewFilesProcessed {
+					return true
+				}
+			}
+
+			return false
+		},
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return true
+		},
+	}
+}
+
+func NewFilesChunkedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+
+			oldCG, oldOk := e.ObjectOld.(*operatorv1alpha1.ChunksGenerator)
+			newCG, newOk := e.ObjectNew.(*operatorv1alpha1.ChunksGenerator)
+
+			if oldOk && newOk {
+				if oldCG.Status.IsNewFilesChunked != newCG.Status.IsNewFilesChunked {
+					return true
+				}
+			}
+
+			return false
+		},
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return true
+		},
+	}
+}
+
+func NewFilesEmbeddedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+
+			oldVEG, oldOk := e.ObjectOld.(*operatorv1alpha1.VectorEmbeddingsGenerator)
+			newVEG, newOk := e.ObjectNew.(*operatorv1alpha1.VectorEmbeddingsGenerator)
+
+			if oldOk && newOk {
+				if oldVEG.Status.IsNewFilesEmbedded != newVEG.Status.IsNewFilesEmbedded {
+					return true
+				}
+			}
+
+			return false
+		},
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return true
+		},
+	}
+}

--- a/internal/controller/documentprocessor_controller.go
+++ b/internal/controller/documentprocessor_controller.go
@@ -24,12 +24,17 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/internal/controller/controllerutils"
@@ -60,6 +65,7 @@ type DocumentProcessorReconciler struct {
 // +kubebuilder:rbac:groups=operator.dataverse.redhat.com,namespace=unstructured-controller-namespace,resources=documentprocessors/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.dataverse.redhat.com,namespace=unstructured-controller-namespace,resources=documentprocessors/finalizers,verbs=update
 
+//nolint:gocyclo
 func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("reconciling", "controller", DocumentProcessorControllerName)
@@ -73,23 +79,43 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	if !isHealthy {
 		logger.Info("Config CR is not ready yet, will try again in a bit ...")
-		return ctrl.Result{
-			RequeueAfter: 10 * time.Second,
-		}, nil
+		return ctrl.Result{}, nil
 	}
 
 	documentProcessorCR := &operatorv1alpha1.DocumentProcessor{}
 	if err := r.Get(ctx, req.NamespacedName, documentProcessorCR); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			logger.Info("DocumentProcessor CR not found, may have been deleted or not yet created")
+			return ctrl.Result{}, nil
+		}
 		logger.Error(err, "failed to get DocumentProcessor CR")
 		return ctrl.Result{}, err
 	}
 
-	documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
-	if err := controllerutils.RemoveForceReconcileLabelWithRetry(ctx, r.Client, documentProcessorKey,
-		func() client.Object { return &operatorv1alpha1.DocumentProcessor{} }); err != nil {
-		logger.Error(err, "error removing the force-reconcile label from the DocumentProcessor CR")
-		return ctrl.Result{}, err
+	isNewFileProcessed := false
+
+	// Skip early-exit checks if we have pending jobs to process
+	if len(documentProcessorCR.Status.Jobs) == 0 && len(documentProcessorCR.Status.Conditions) > 0 {
+		unstructuredDataProdcutKey := client.ObjectKey{
+			Namespace: documentProcessorCR.Namespace,
+			Name:      documentProcessorCR.Spec.DataProduct,
+		}
+		unstructuredDataProductCR := &operatorv1alpha1.UnstructuredDataProduct{}
+		err = r.Get(ctx, unstructuredDataProdcutKey, unstructuredDataProductCR)
+		if err == nil {
+			logger.Info("successfully got UnstructuredDataProduct CR", "namespace", unstructuredDataProductCR.Namespace, "name", unstructuredDataProductCR.Name)
+			for _, condition := range unstructuredDataProductCR.Status.Conditions {
+				if (condition.Type == operatorv1alpha1.UnstructuredDataProductCondition && condition.Status == metav1.ConditionUnknown) ||
+					(condition.Type == operatorv1alpha1.UnstructuredDataProductCondition && condition.Status == metav1.ConditionTrue && !unstructuredDataProductCR.Status.IsNewFilesDetected) ||
+					(condition.Type == operatorv1alpha1.UnstructuredDataProductCondition && condition.Status == metav1.ConditionFalse) {
+					logger.Info("This event is triggered because of watches on UnstructuredDataProduct CR and its status is either waiting or no new files detected so do early exit to avoid duplicate processing", "namespace", unstructuredDataProductCR.Namespace, "name", unstructuredDataProductCR.Name)
+					return ctrl.Result{}, nil
+				}
+			}
+		}
 	}
+
+	documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
 
 	// set status to waiting
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -122,11 +148,15 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		logger.Error(err, "failed to create filestore")
-		return r.handleError(ctx, documentProcessorCR, err)
+		return r.handleError(ctx, documentProcessorCR, err, isNewFileProcessed)
 	}
 	r.fileStore = fs
 
 	// first, let's figure out the jobs that are currently running
+	if len(documentProcessorCR.Status.Jobs) > 0 {
+		logger.Info("found jobs in status, reconciling ...", "job count", len(documentProcessorCR.Status.Jobs))
+		isNewFileProcessed = true
+	}
 	jobProcessingErrors := []error{}
 	for _, job := range documentProcessorCR.Status.Jobs {
 		logger.Info("reconciling job", "job", job)
@@ -141,7 +171,7 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	filePaths, err := r.fileStore.ListFilesInPath(ctx, dataProductName)
 	if err != nil {
 		logger.Error(err, "failed to list files in path")
-		return r.handleError(ctx, documentProcessorCR, err)
+		return r.handleError(ctx, documentProcessorCR, err, isNewFileProcessed)
 	}
 
 	documentProcessingErrors := []error{}
@@ -154,21 +184,8 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	// add force reconcile label to the ChunksGenerator CR
-	chunksGeneratorKey := client.ObjectKey{Namespace: documentProcessorCR.Namespace, Name: documentProcessorCR.Name}
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		chunksGeneratorCR := &operatorv1alpha1.ChunksGenerator{}
-		if err := r.Get(ctx, chunksGeneratorKey, chunksGeneratorCR); err != nil {
-			return err
-		}
-		return controllerutils.AddForceReconcileLabel(ctx, r.Client, chunksGeneratorCR)
-	}); err != nil {
-		logger.Error(err, "failed to add force reconcile label to ChunksGenerator CR")
-		return r.handleError(ctx, documentProcessorCR, err)
-	}
-
 	if len(documentProcessingErrors) > 0 || len(jobProcessingErrors) > 0 {
-		return r.handleError(ctx, documentProcessorCR, errors.New("failed to process jobs or documents"))
+		return r.handleError(ctx, documentProcessorCR, errors.New("failed to process jobs or documents"), isNewFileProcessed)
 	}
 
 	latestDocumentProcessorCR := &operatorv1alpha1.DocumentProcessor{}
@@ -192,11 +209,11 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err := r.Get(ctx, documentProcessorKey, res); err != nil {
 			return err
 		}
-		res.UpdateStatus(successMessage, nil)
+		res.UpdateStatus(successMessage, nil, isNewFileProcessed)
 		return r.Status().Update(ctx, res)
 	}); err != nil {
 		logger.Error(err, "failed to update DocumentProcessor CR status", "namespace", latestDocumentProcessorCR.Namespace, "name", latestDocumentProcessorCR.Name)
-		return r.handleError(ctx, documentProcessorCR, err)
+		return r.handleError(ctx, documentProcessorCR, err, isNewFileProcessed)
 	}
 	logger.Info("successfully updated DocumentProcessor CR status", "status", latestDocumentProcessorCR.Status)
 
@@ -487,15 +504,25 @@ func (r *DocumentProcessorReconciler) needsConversion(ctx context.Context, rawFi
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DocumentProcessorReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	labelPredicate := controllerutils.ForceReconcilePredicate()
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1alpha1.DocumentProcessor{}).
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, labelPredicate)).
+		For(&operatorv1alpha1.DocumentProcessor{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&operatorv1alpha1.UnstructuredDataProduct{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+				return []reconcile.Request{{
+					NamespacedName: types.NamespacedName{
+						Name:      obj.GetName(),
+						Namespace: obj.GetNamespace(),
+					},
+				}}
+			}),
+			builder.WithPredicates(controllerutils.NewFilesDetectedPredicate()),
+		).
 		Named("documentprocessor").
 		Complete(r)
 }
 
-func (r *DocumentProcessorReconciler) handleError(ctx context.Context, documentProcessorCR *operatorv1alpha1.DocumentProcessor, err error) (ctrl.Result, error) {
+func (r *DocumentProcessorReconciler) handleError(ctx context.Context, documentProcessorCR *operatorv1alpha1.DocumentProcessor, err error, isNewFileProcessed bool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
@@ -505,7 +532,7 @@ func (r *DocumentProcessorReconciler) handleError(ctx context.Context, documentP
 		if getErr := r.Get(ctx, documentProcessorKey, latest); getErr != nil {
 			return getErr
 		}
-		latest.UpdateStatus("", reconcileErr)
+		latest.UpdateStatus("", reconcileErr, isNewFileProcessed)
 		return r.Status().Update(ctx, latest)
 	}); err != nil {
 		logger.Error(err, "failed to update DocumentProcessor CR status")

--- a/internal/controller/unstructureddataproduct_controller.go
+++ b/internal/controller/unstructureddataproduct_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -59,6 +60,7 @@ type UnstructuredDataProductReconciler struct {
 // +kubebuilder:rbac:groups=operator.dataverse.redhat.com,namespace=unstructured-controller-namespace,resources=unstructureddataproducts/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.dataverse.redhat.com,namespace=unstructured-controller-namespace,resources=unstructureddataproducts/finalizers,verbs=update
 
+//nolint:gocyclo
 func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("reconciling", "controller", UnstructuredDataProductControllerName)
@@ -83,6 +85,72 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 	dataProductName := unstructuredDataProductCR.Name
+	isNewFileDetected := false
+	hasForceReconcileLabel := controllerutils.HasForceReconcileLabel(unstructuredDataProductCR)
+
+	if !hasForceReconcileLabel {
+		// Check if document processor is there for this data product
+		documentProcessorKey := client.ObjectKey{
+			Namespace: unstructuredDataProductCR.Namespace,
+			Name:      dataProductName,
+		}
+		existingDocumentProcessorCR := &operatorv1alpha1.DocumentProcessor{}
+		err = r.Get(ctx, documentProcessorKey, existingDocumentProcessorCR)
+		if err == nil {
+			logger.Info("DocumentProcessor CR already exists for this data product, now checking for the status", "documentProcessorCR", existingDocumentProcessorCR.Name)
+			for _, condition := range existingDocumentProcessorCR.Status.Conditions {
+				if condition.Type == operatorv1alpha1.DocumentProcessorCondition && condition.Status == metav1.ConditionUnknown {
+					logger.Info("DocumentProcessor CR is in waiting state, this event is triggered because of Owns and it is setWaiting in the document processor reconciler, will do early exit", "documentProcessorCR", existingDocumentProcessorCR.Name)
+					return ctrl.Result{}, nil
+				}
+			}
+		} else if client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "failed to get DocumentProcessor CR")
+			return ctrl.Result{}, err
+		}
+
+		// check if chunks generator is there for this data product
+		chunksGeneratorKey := client.ObjectKey{
+			Namespace: unstructuredDataProductCR.Namespace,
+			Name:      dataProductName,
+		}
+		existingChunksGeneratorCR := &operatorv1alpha1.ChunksGenerator{}
+		err = r.Get(ctx, chunksGeneratorKey, existingChunksGeneratorCR)
+		if err == nil {
+			logger.Info("ChunksGenerator CR already exists for this data product, now checking for the status", "chunksGeneratorCR", existingChunksGeneratorCR.Name)
+			for _, condition := range existingChunksGeneratorCR.Status.Conditions {
+				if condition.Type == operatorv1alpha1.ChunksGeneratorCondition && condition.Status == metav1.ConditionUnknown {
+					logger.Info("ChunksGenerator CR is in waiting state, this event is triggered because of Owns and it is setWaiting in the chunks generator reconciler, will do early exit", "chunksGeneratorCR", existingChunksGeneratorCR.Name)
+					return ctrl.Result{}, nil
+				}
+			}
+		} else if client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "failed to get ChunksGenerator CR")
+			return ctrl.Result{}, err
+		}
+
+		//check if vector embeddings generator is there for this data product
+		vectorEmbeddingsGeneratorKey := client.ObjectKey{
+			Namespace: unstructuredDataProductCR.Namespace,
+			Name:      dataProductName,
+		}
+		existingVectorEmbeddingsGeneratorCR := &operatorv1alpha1.VectorEmbeddingsGenerator{}
+		err = r.Get(ctx, vectorEmbeddingsGeneratorKey, existingVectorEmbeddingsGeneratorCR)
+		if err == nil {
+			logger.Info("VectorEmbeddingsGenerator CR already exists for this data product, now checking for the status", "vectorEmbeddingsGeneratorCR", existingVectorEmbeddingsGeneratorCR.Name)
+			for _, condition := range existingVectorEmbeddingsGeneratorCR.Status.Conditions {
+				if condition.Type == operatorv1alpha1.VectorEmbeddingGenerationConditionType && condition.Status == metav1.ConditionUnknown {
+					logger.Info("VectorEmbeddingsGenerator CR is in waiting state, this event is triggered because of Owns and it is setWaiting in the vector embeddings generator reconciler, will do early exit", "vectorEmbeddingsGeneratorCR", existingVectorEmbeddingsGeneratorCR.Name)
+					return ctrl.Result{}, nil
+				}
+			}
+		} else if client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "failed to get VectorEmbeddingsGenerator CR")
+			return ctrl.Result{}, err
+		}
+	} else {
+		logger.Info("force-reconcile label present, skipping early-exit checks to process new files from SQS/manual trigger")
+	}
 
 	unstructuredDataProductKey := client.ObjectKeyFromObject(unstructuredDataProductCR)
 	if err := controllerutils.RemoveForceReconcileLabelWithRetry(ctx, r.Client, unstructuredDataProductKey,
@@ -114,7 +182,11 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 			DocumentProcessorConfig: unstructuredDataProductCR.Spec.DocumentProcessorConfig,
 		},
 	}
-	// result, err := kubecontrollerutil.CreateOrUpdate(ctx, r.Client, documentProcessorCR, func() error { return nil })
+
+	if err := ctrl.SetControllerReference(unstructuredDataProductCR, documentProcessorCR, r.Scheme); err != nil {
+		logger.Error(err, "failed to set controller reference for DocumentProcessor CR")
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
+	}
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, documentProcessorCR, func() error {
 		documentProcessorCR.Spec = operatorv1alpha1.DocumentProcessorSpec{
 			DataProduct:             dataProductName,
@@ -124,7 +196,7 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 	})
 	if err != nil {
 		logger.Error(err, "failed to create/update DocumentProcessor CR")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
 	logger.Info("DocumentProcessor CR created/updated", "result", result)
 
@@ -139,6 +211,10 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 			ChunksGeneratorConfig: unstructuredDataProductCR.Spec.ChunksGeneratorConfig,
 		},
 	}
+	if err := ctrl.SetControllerReference(unstructuredDataProductCR, chunksGeneratorCR, r.Scheme); err != nil {
+		logger.Error(err, "failed to set controller reference for ChunksGenerator CR")
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
+	}
 	result, err = controllerutil.CreateOrUpdate(ctx, r.Client, chunksGeneratorCR, func() error {
 		chunksGeneratorCR.Spec = operatorv1alpha1.ChunksGeneratorSpec{
 			DataProduct:           dataProductName,
@@ -148,7 +224,7 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 	})
 	if err != nil {
 		logger.Error(err, "failed to create/update ChunksGenerator CR")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
 	logger.Info("ChunksGenerator CR created/updated", "result", result)
 
@@ -163,7 +239,10 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 			VectorEmbeddingsGeneratorConfig: unstructuredDataProductCR.Spec.VectorEmbeddingsGeneratorConfig,
 		},
 	}
-
+	if err := ctrl.SetControllerReference(unstructuredDataProductCR, vectorEmbeddingsGeneratorCR, r.Scheme); err != nil {
+		logger.Error(err, "failed to set controller reference for VectorEmbeddingsGenerator CR")
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
+	}
 	result, err = controllerutil.CreateOrUpdate(ctx, r.Client, vectorEmbeddingsGeneratorCR, func() error {
 		vectorEmbeddingsGeneratorCR.Spec = operatorv1alpha1.VectorEmbeddingsGeneratorSpec{
 			DataProduct:                     dataProductName,
@@ -173,7 +252,7 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 	})
 	if err != nil {
 		logger.Error(err, "failed to create/update VectorEmbeddingsGenerator CR")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
 	logger.Info("VectorEmbeddingsGenerator CR created/updated", "result", result)
 
@@ -186,7 +265,7 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 			Prefix: unstructuredDataProductCR.Spec.SourceConfig.S3Config.Prefix,
 		}
 	default:
-		return r.handleError(ctx, unstructuredDataProductCR, fmt.Errorf("unsupported source type: %s", unstructuredDataProductCR.Spec.SourceConfig.Type))
+		return r.handleError(ctx, unstructuredDataProductCR, fmt.Errorf("unsupported source type: %s", unstructuredDataProductCR.Spec.SourceConfig.Type), isNewFileDetected)
 	}
 
 	if !IsControllerConfigGlobalsSet(cacheDirectory, dataStorageBucket) {
@@ -200,7 +279,7 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		logger.Error(err, "failed to create filestore")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
 
 	r.fileStore = fs
@@ -220,28 +299,12 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 	// data-storage-bucket/dataproduct/file1.pdf-chunks.json
 	// data-storage-bucket/dataproduct/file1.pdf-vector-embeddings.json
 
-	storedFiles, err := source.SyncFilesToFilestore(ctx, r.fileStore)
+	isNewFileDetected, storedFiles, err := source.SyncFilesToFilestore(ctx, r.fileStore)
 	if err != nil {
 		logger.Error(err, "failed to store files to filestore")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
-	logger.Info("successfully stored files to filestore", "files", storedFiles)
-
-	// add force reconcile label to the DocumentProcessor CR
-	documentProcessorKey := client.ObjectKey{
-		Namespace: unstructuredDataProductCR.Namespace,
-		Name:      dataProductName,
-	}
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latestDocumentProcessorCR := &operatorv1alpha1.DocumentProcessor{}
-		if getErr := r.Get(ctx, documentProcessorKey, latestDocumentProcessorCR); getErr != nil {
-			return getErr
-		}
-		return controllerutils.AddForceReconcileLabel(ctx, r.Client, latestDocumentProcessorCR)
-	}); err != nil {
-		logger.Error(err, "failed to add force reconcile label to DocumentProcessor CR")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
-	}
+	logger.Info("successfully stored files to filestore", "files", storedFiles, "isNewFileDetected", isNewFileDetected)
 
 	// Setup destination
 	var destination unstructured.Destination
@@ -249,7 +312,7 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 	case operatorv1alpha1.DestinationTypeInternalStage:
 		destination, err = r.setupSnowflakeDestination(ctx, unstructuredDataProductCR)
 		if err != nil {
-			return r.handleError(ctx, unstructuredDataProductCR, err)
+			return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 		}
 	case operatorv1alpha1.TypeS3:
 		destination, err = setupS3Destination(unstructuredDataProductCR, dataProductName)
@@ -258,19 +321,19 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 				logger.Info("ControllerConfig has not initialized destination S3 client yet, will try again in a bit ...")
 				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
-			return r.handleError(ctx, unstructuredDataProductCR, err)
+			return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 		}
 	default:
 		err = fmt.Errorf("unsupported destination type: %s", unstructuredDataProductCR.Spec.DestinationConfig.Type)
 		logger.Error(err, "unsupported destination type")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
 
 	// list all files in the filestore for the data product
 	filePaths, err := r.fileStore.ListFilesInPath(ctx, dataProductName)
 	if err != nil {
 		logger.Error(err, "failed to list files in path")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
 	// extract the vector embeddings files that are to be ingested to destination
 	filterEmbeddingsFiles := unstructured.FilterVectorEmbeddingsFilePaths(filePaths)
@@ -279,17 +342,17 @@ func (r *UnstructuredDataProductReconciler) Reconcile(ctx context.Context, req c
 	// ingest the embeddings files to destination
 	if err = destination.SyncFilesToDestination(ctx, r.fileStore, filterEmbeddingsFiles); err != nil {
 		logger.Error(err, "failed to ingest embeddings files to destination")
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
 	logger.Info("successfully ingested embeddings files to destination")
 
 	// all done, let's update the status to ready
 	successMessage := fmt.Sprintf("successfully reconciled unstructured data product: %s", dataProductName)
 	if err = controllerutils.StatusUpdateWithRetry(ctx, r.Client, unstructuredDataProductKey, func() client.Object { return &operatorv1alpha1.UnstructuredDataProduct{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.UnstructuredDataProduct).UpdateStatus(successMessage, nil)
+		obj.(*operatorv1alpha1.UnstructuredDataProduct).UpdateStatus(successMessage, nil, isNewFileDetected)
 	}); err != nil {
 		logger.Error(err, "failed to update UnstructuredDataProduct CR status", "namespace", unstructuredDataProductKey.Namespace, "name", unstructuredDataProductKey.Name)
-		return r.handleError(ctx, unstructuredDataProductCR, err)
+		return r.handleError(ctx, unstructuredDataProductCR, err, isNewFileDetected)
 	}
 	logger.Info("successfully updated UnstructuredDataProduct CR status", "status", unstructuredDataProductCR.Status)
 
@@ -337,17 +400,19 @@ func setupS3Destination(unstructuredDataProductCR *operatorv1alpha1.Unstructured
 func (r *UnstructuredDataProductReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	labelPredicate := controllerutils.ForceReconcilePredicate()
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1alpha1.UnstructuredDataProduct{}).
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, labelPredicate)).
+		For(&operatorv1alpha1.UnstructuredDataProduct{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, labelPredicate))).
+		Owns(&operatorv1alpha1.DocumentProcessor{}).
+		Owns(&operatorv1alpha1.ChunksGenerator{}).
+		Owns(&operatorv1alpha1.VectorEmbeddingsGenerator{}).
 		Complete(r)
 }
 
-func (r *UnstructuredDataProductReconciler) handleError(ctx context.Context, unstructuredDataProductCR *operatorv1alpha1.UnstructuredDataProduct, err error) (ctrl.Result, error) {
+func (r *UnstructuredDataProductReconciler) handleError(ctx context.Context, unstructuredDataProductCR *operatorv1alpha1.UnstructuredDataProduct, err error, isNewFileDetected bool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	unstructuredDataProductKey := client.ObjectKeyFromObject(unstructuredDataProductCR)
 	if updateErr := controllerutils.StatusUpdateWithRetry(ctx, r.Client, unstructuredDataProductKey, func() client.Object { return &operatorv1alpha1.UnstructuredDataProduct{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.UnstructuredDataProduct).UpdateStatus("", err)
+		obj.(*operatorv1alpha1.UnstructuredDataProduct).UpdateStatus("", err, isNewFileDetected)
 	}); updateErr != nil {
 		logger.Error(updateErr, "failed to update UnstructuredDataProduct CR status")
 		return ctrl.Result{}, updateErr

--- a/internal/controller/vectorembeddingsgenerator_controller.go
+++ b/internal/controller/vectorembeddingsgenerator_controller.go
@@ -24,12 +24,17 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/internal/controller/controllerutils"
@@ -73,8 +78,32 @@ func (r *VectorEmbeddingsGeneratorReconciler) Reconcile(ctx context.Context, req
 	// get the vector embedding generation CR
 	vectorEmbeddingsGeneratorCR := &operatorv1alpha1.VectorEmbeddingsGenerator{}
 	if err := r.Get(ctx, req.NamespacedName, vectorEmbeddingsGeneratorCR); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			logger.Info("VectorEmbeddingsGenerator CR not found, may have been deleted or not yet created")
+			return ctrl.Result{}, nil
+		}
 		logger.Error(err, "failed to get VectorEmbeddingsGenerator CR")
 		return ctrl.Result{}, err
+	}
+
+	embedded := false
+
+	// Only do early-exit checks if this CR already has status initialized to ensure initial status set
+	if len(vectorEmbeddingsGeneratorCR.Status.Conditions) > 0 {
+		chunksGeneratorKey := client.ObjectKey{Namespace: vectorEmbeddingsGeneratorCR.Namespace, Name: vectorEmbeddingsGeneratorCR.Spec.DataProduct}
+		chunksGeneratorCR := &operatorv1alpha1.ChunksGenerator{}
+		err = r.Get(ctx, chunksGeneratorKey, chunksGeneratorCR)
+		if err == nil {
+			logger.Info("successfully got ChunksGenerator CR", "namespace", chunksGeneratorCR.Namespace, "name", chunksGeneratorCR.Name)
+			for _, condition := range chunksGeneratorCR.Status.Conditions {
+				if (condition.Type == operatorv1alpha1.ChunksGeneratorCondition && condition.Status == metav1.ConditionUnknown) ||
+					(condition.Type == operatorv1alpha1.ChunksGeneratorCondition && condition.Status == metav1.ConditionFalse) ||
+					(condition.Type == operatorv1alpha1.ChunksGeneratorCondition && condition.Status == metav1.ConditionTrue && !chunksGeneratorCR.Status.IsNewFilesChunked) {
+					logger.Info("This event is triggered because of watches on ChunksGenerator CR and its status is either waiting or no new files chunked so do early exit to avoid duplicate processing", "namespace", chunksGeneratorCR.Namespace, "name", chunksGeneratorCR.Name)
+					return ctrl.Result{}, nil
+				}
+			}
+		}
 	}
 
 	// set status to waiting
@@ -98,7 +127,7 @@ func (r *VectorEmbeddingsGeneratorReconciler) Reconcile(ctx context.Context, req
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		logger.Error(err, "failed to create the filestore client")
-		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err)
+		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err, embedded)
 	}
 	r.fileStore = fs
 
@@ -107,26 +136,13 @@ func (r *VectorEmbeddingsGeneratorReconciler) Reconcile(ctx context.Context, req
 	logger.Info("files in path", "files", filePaths)
 	if err != nil {
 		logger.Error(err, "failed to list files in path")
-		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err)
-	}
-
-	// now that we have the list of files to process, we may remove the force reconcile label as we are ready to accept more events
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.VectorEmbeddingsGenerator{}
-		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-			return err
-		}
-		return controllerutils.RemoveForceReconcileLabel(ctx, r.Client, latest)
-	}); err != nil {
-		logger.Error(err, "failed to remove force reconcile label from VectorEmbeddingsGenerator CR")
-		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err)
+		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err, embedded)
 	}
 
 	chunksFilePaths := unstructured.FilterChunksFilePaths(filePaths)
 	logger.Info("chunks filepaths filtered successfully", "chunksFilePaths", chunksFilePaths)
 
 	embeddingErrors := []error{}
-	var embedded bool
 	for _, chunksFilePath := range chunksFilePaths {
 		logger.Info("processing chunked file for embedding", "file", chunksFilePath)
 		fileEmbedded, err := r.processChunkedFile(ctx, chunksFilePath, vectorEmbeddingsGeneratorCR)
@@ -142,7 +158,7 @@ func (r *VectorEmbeddingsGeneratorReconciler) Reconcile(ctx context.Context, req
 
 	if len(embeddingErrors) > 0 {
 		logger.Error(embeddingErrors[0], "failed to process some chunked files")
-		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, errors.New("failed to process some chunked files"))
+		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, errors.New("failed to process some chunked files"), embedded)
 	}
 
 	// Add force reconcile to unstructured data product if any of the file got embedded during this reconciliation
@@ -156,7 +172,7 @@ func (r *VectorEmbeddingsGeneratorReconciler) Reconcile(ctx context.Context, req
 			return controllerutils.AddForceReconcileLabel(ctx, r.Client, unstructuredDataProduct)
 		}); err != nil {
 			logger.Error(err, "failed to add force reconcile label to UnstructuredDataProduct CR")
-			return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err)
+			return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err, embedded)
 		}
 		logger.Info("successfully added force reconcile label to UnstructuredDataProduct CR")
 	} else {
@@ -171,11 +187,11 @@ func (r *VectorEmbeddingsGeneratorReconciler) Reconcile(ctx context.Context, req
 		if err := r.Get(ctx, vectorEmbeddingsGeneratorKey, res); err != nil {
 			return err
 		}
-		res.UpdateStatus(successMessage, nil)
+		res.UpdateStatus(successMessage, nil, embedded)
 		return r.Status().Update(ctx, res)
 	}); err != nil {
 		logger.Error(err, "failed to update VectorEmbeddingsGenerator CR status", "namespace", vectorEmbeddingsGeneratorKey.Namespace, "name", vectorEmbeddingsGeneratorKey.Name)
-		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err)
+		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err, embedded)
 	}
 	logger.Info("successfully updated VectorEmbeddingsGenerator CR status", "status", vectorEmbeddingsGeneratorCR.Status)
 
@@ -379,7 +395,7 @@ func (r *VectorEmbeddingsGeneratorReconciler) needsEmbedding(ctx context.Context
 	return true, nil
 }
 
-func (r *VectorEmbeddingsGeneratorReconciler) handleError(ctx context.Context, vectorEmbeddingsGeneratorCR *operatorv1alpha1.VectorEmbeddingsGenerator, err error) (ctrl.Result, error) {
+func (r *VectorEmbeddingsGeneratorReconciler) handleError(ctx context.Context, vectorEmbeddingsGeneratorCR *operatorv1alpha1.VectorEmbeddingsGenerator, err error, isEmbedded bool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
@@ -389,7 +405,7 @@ func (r *VectorEmbeddingsGeneratorReconciler) handleError(ctx context.Context, v
 		if getErr := r.Get(ctx, key, latest); getErr != nil {
 			return getErr
 		}
-		latest.UpdateStatus("", reconcileErr)
+		latest.UpdateStatus("", reconcileErr, isEmbedded)
 		return r.Status().Update(ctx, latest)
 	}); err != nil {
 		logger.Error(err, "failed to update VectorEmbeddingsGenerator CR status")
@@ -400,9 +416,19 @@ func (r *VectorEmbeddingsGeneratorReconciler) handleError(ctx context.Context, v
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *VectorEmbeddingsGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	labelPredicate := controllerutils.ForceReconcilePredicate()
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1alpha1.VectorEmbeddingsGenerator{}).
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, labelPredicate)).
+		For(&operatorv1alpha1.VectorEmbeddingsGenerator{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&operatorv1alpha1.ChunksGenerator{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+				return []reconcile.Request{{
+					NamespacedName: types.NamespacedName{
+						Name:      obj.GetName(),
+						Namespace: obj.GetNamespace(),
+					},
+				}}
+			}),
+			builder.WithPredicates(controllerutils.NewFilesChunkedPredicate()),
+		).
 		Complete(r)
 }

--- a/pkg/unstructured/source.go
+++ b/pkg/unstructured/source.go
@@ -31,7 +31,7 @@ import (
 
 type DataSource interface {
 	// SyncFilesToFilestore will store all files from the source to the filestore and return the list of file paths
-	SyncFilesToFilestore(ctx context.Context, fs *filestore.FileStore) ([]RawFileMetadata, error)
+	SyncFilesToFilestore(ctx context.Context, fs *filestore.FileStore) (bool, []RawFileMetadata, error)
 }
 
 type S3BucketSource struct {
@@ -39,16 +39,19 @@ type S3BucketSource struct {
 	Prefix string
 }
 
-func (s *S3BucketSource) SyncFilesToFilestore(ctx context.Context, fs *filestore.FileStore) ([]RawFileMetadata, error) {
+func (s *S3BucketSource) SyncFilesToFilestore(
+	ctx context.Context, fs *filestore.FileStore,
+) (bool, []RawFileMetadata, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("listing objects in prefix", "bucket", s.Bucket, "prefix", s.Prefix)
+	isNewFileDetected := false
 	sourceS3Client, err := awsclienthandler.GetSourceS3Client()
 	if err != nil {
-		return nil, err
+		return isNewFileDetected, nil, err
 	}
 	objects, err := awsclienthandler.ListObjectsInPrefix(ctx, sourceS3Client, s.Bucket, s.Prefix)
 	if err != nil {
-		return nil, err
+		return isNewFileDetected, nil, err
 	}
 
 	storedFiles := []RawFileMetadata{}
@@ -68,12 +71,16 @@ func (s *S3BucketSource) SyncFilesToFilestore(ctx context.Context, fs *filestore
 		// file: testunstructureddataproduct/12.pdf
 		logger.Info("storing file", "file", file.FilePath)
 		sourceFileMap[file.FilePath] = true
-
-		if err := s.storeFile(ctx, fs, &file); err != nil {
+		var isNewFileStored bool
+		if isNewFileStored, err = s.storeFile(ctx, fs, &file); err != nil {
 			logger.Error(err, "failed to store file", "file", file.FilePath)
 			errorList[file.FilePath] = err
 			continue
 		}
+		if isNewFileStored {
+			isNewFileDetected = true
+		}
+
 		logger.Info("successfully stored file", "file", file.FilePath)
 		storedFiles = append(storedFiles, file)
 	}
@@ -81,7 +88,7 @@ func (s *S3BucketSource) SyncFilesToFilestore(ctx context.Context, fs *filestore
 	localFiles, err := fs.ListFilesInPath(ctx, s.Prefix)
 	if err != nil {
 		logger.Error(err, "failed to list files in filestore", "prefix", s.Prefix)
-		return nil, err
+		return isNewFileDetected, nil, err
 	}
 
 	// logic to delete files and its respective files if the file is removed from upstream bucket
@@ -111,15 +118,15 @@ func (s *S3BucketSource) SyncFilesToFilestore(ctx context.Context, fs *filestore
 		errorMessage += fmt.Sprintf("file: %s, error: %v\n", filePath, err)
 	}
 	if len(errorMessage) > 0 {
-		return nil, errors.New(errorMessage)
+		return isNewFileDetected, nil, errors.New(errorMessage)
 	}
 
-	return storedFiles, nil
+	return isNewFileDetected, storedFiles, nil
 }
 
 // storeFile will store the given file to the filestore
 // it will make sure that the file is unique by comparing the object's ETag with the file's metadata
-func (s *S3BucketSource) storeFile(ctx context.Context, fs *filestore.FileStore, file *RawFileMetadata) error {
+func (s *S3BucketSource) storeFile(ctx context.Context, fs *filestore.FileStore, file *RawFileMetadata) (bool, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("storing file", "file", file.FilePath)
 
@@ -132,13 +139,13 @@ func (s *S3BucketSource) storeFile(ctx context.Context, fs *filestore.FileStore,
 	fileExists, err := fs.Exists(ctx, filePath)
 	if err != nil {
 		logger.Error(err, "failed to check if file exists in filestore", "file", filePath)
-		return err
+		return false, err
 	}
 
 	metadataExists, err := fs.Exists(ctx, metadataPath)
 	if err != nil {
 		logger.Error(err, "failed to check if metadata file exists in filestore", "file", metadataPath)
-		return err
+		return false, err
 	}
 
 	if fileExists && metadataExists {
@@ -149,7 +156,7 @@ func (s *S3BucketSource) storeFile(ctx context.Context, fs *filestore.FileStore,
 		metadata, err := fs.Retrieve(ctx, metadataPath)
 		if err != nil {
 			logger.Error(err, "failed to retrieve metadata file from filestore", "file", metadataPath)
-			return err
+			return false, err
 		}
 
 		// unmarshal the metadata file into a FileMetadata struct
@@ -157,13 +164,13 @@ func (s *S3BucketSource) storeFile(ctx context.Context, fs *filestore.FileStore,
 		err = json.Unmarshal(metadata, &existingFile)
 		if err != nil {
 			logger.Error(err, "failed to unmarshal metadata file", "file", metadataPath)
-			return err
+			return false, err
 		}
 
 		if existingFile.UID == file.UID {
 			// the file and the metadata file are the same, so we can skip storing it
 			logger.Info("file and metadata file are the same, skipping ...", "file", filePath)
-			return nil
+			return false, nil
 		}
 	}
 
@@ -174,29 +181,29 @@ func (s *S3BucketSource) storeFile(ctx context.Context, fs *filestore.FileStore,
 	objectOutput, err := awsclienthandler.GetObject(ctx, s.Bucket, filePath)
 	if err != nil {
 		logger.Error(err, "failed to get object from S3", "file", filePath)
-		return err
+		return false, err
 	}
 
 	data, err := io.ReadAll(objectOutput.Body)
 	if err != nil {
 		logger.Error(err, "failed to read object from S3", "file", filePath)
-		return err
+		return false, err
 	}
 	if err = fs.Store(ctx, filePath, data); err != nil {
 		logger.Error(err, "failed to store file in filestore", "file", filePath)
-		return err
+		return false, err
 	}
 
 	metadataData, err := json.Marshal(file)
 	if err != nil {
 		logger.Error(err, "failed to marshal metadata file", "file", metadataPath)
-		return err
+		return false, err
 	}
 	if err = fs.Store(ctx, metadataPath, metadataData); err != nil {
 		logger.Error(err, "failed to store metadata file in filestore", "file", metadataPath)
-		return err
+		return false, err
 	}
 
 	logger.Info("successfully stored file and metadata file in filestore", "file", filePath, "metadataFile", metadataPath)
-	return nil
+	return true, nil
 }


### PR DESCRIPTION
Replace the force-reconcile label pattern with Watches(), Owns() relationships
  and custom status field predicates for controller chain triggering.

  - Add custom predicates for IsNewFilesDetected/Processed/Chunked/Embedded
  - Use Watches() with EnqueueRequestsFromMapFunc to watch upstream controllers
  - Add early-exit checks to prevent duplicate processing from Owns() events
  - Skip early-exit when force-reconcile label present (SQS) or jobs pending
  - Move predicates to For() to avoid filtering Owns() events
  - Fix NotFound error logging order