### PR TITLE
fix(langchain): remove duplicate DisallowedSpecial and SecondSplitter appends

### DIFF
--- a/pkg/langchain/client.go
+++ b/pkg/langchain/client.go
@@ -106,12 +106,6 @@ func convertOptionsToOptionList(options *textsplitter.Options) []textsplitter.Op
 	if options.SecondSplitter != nil {
 		optionList = append(optionList, textsplitter.WithSecondSplitter(options.SecondSplitter))
 	}
-	if len(options.DisallowedSpecial) > 0 {
-		optionList = append(optionList, textsplitter.WithDisallowedSpecial(options.DisallowedSpecial))
-	}
-	if options.SecondSplitter != nil {
-		optionList = append(optionList, textsplitter.WithSecondSplitter(options.SecondSplitter))
-	}
 	if options.CodeBlocks {
 		optionList = append(optionList, textsplitter.WithCodeBlocks(options.CodeBlocks))
 	}


### PR DESCRIPTION
Closes #184

`DisallowedSpecial` and `SecondSplitter` were each appended twice to the option list in `convertOptionsToOptionList` (`pkg/langchain/client.go`). Removed the duplicate block at lines 109-114.