### PR TITLE
fix(controller): correct inverted log message in needsChunking

### DIFF
--- a/internal/controller/chunksgenerator_controller.go
+++ b/internal/controller/chunksgenerator_controller.go
@@ -274,7 +274,7 @@ func (r *ChunksGeneratorReconciler) needsChunking(ctx context.Context, converted
 		ChunksGeneratorConfig: chunksGeneratorCR.Spec.ChunksGeneratorConfig,
 	}
 	if !chunksFile.ChunksDocument.Metadata.Equal(&newChunksFileMetadata) {
-		logger.Info("chunks file is the same as the current chunks file in filestore, no need to chunk again", "file", convertedFilePath)
+		logger.Info("chunks file config has changed, re-chunking needed", "file", convertedFilePath)
 		return true, nil
 	}
 


### PR DESCRIPTION
Closes #191

The log message in `needsChunking` printed "chunks file is the same ... no need to chunk again" on the branch that returns `true` (chunks file metadata differs from the new one and re-chunking is needed). Replaced with "chunks file config has changed, re-chunking needed" so logs match the control flow.