### PR TITLE
fix(api): return pointer to slice element in GetJobByFilePath

### DIFF
--- a/api/v1alpha1/documentprocessor_types.go
+++ b/api/v1alpha1/documentprocessor_types.go
@@ -101,9 +101,9 @@ func (d *DocumentProcessor) AddOrUpdateJob(newJob Job) {
 }
 
 func (d *DocumentProcessor) GetJobByFilePath(filePath string) *Job {
-	for _, job := range d.Status.Jobs {
-		if job.FilePath == filePath {
-			return &job
+	for i := range d.Status.Jobs {
+		if d.Status.Jobs[i].FilePath == filePath {
+			return &d.Status.Jobs[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
Closes #177

`GetJobByFilePath` ranged over `d.Status.Jobs` and returned `&job`, a pointer to the loop variable copy. Switched to index-based iteration and returning `&d.Status.Jobs[i]` so callers receive a pointer to the actual slice element and any mutations propagate.