### PR TITLE
Fix github workflow for controller-dep-bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         name: setup go
         with:
           go-version-file: "go.mod"
-          go-version: "1.25.x"
+          go-version: "1.26.x"
       - name: build
         run: |
           go build -v ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         name: setup go
         with:
           go-version-file: "go.mod"
-          go-version: "1.25.x"
+          go-version: "1.26.x"
       - name: gofmt
         run: |
           make fmt
@@ -37,7 +37,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4.0
+          version: v2.10.0
           args: --timeout=10m
       - name: yamllint
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,11 @@ linters:
             - 6
         - name: confusing-results
           disabled: true
+        - name: unsecure-url-scheme
+          disabled: false
+          severity: error
+          exclude:
+            - "http://docling-serve:5001"
   exclusions:
     generated: lax
     rules:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 WORKDIR /opt/app-root/src
 

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.18.0
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
-GOLANGCI_LINT_VERSION ?= v2.1.0
+GOLANGCI_LINT_VERSION ?= v2.10.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.


### PR DESCRIPTION
- using go version 1.25.x , requires >=1.26.x
- update the golangci-lint version to support go 1.26 or higher