### PR TITLE
Modify config for gemini code reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,11 @@
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+ignore_patterns: ["vendor/**"]


### PR DESCRIPTION
Added properties which can govern the gemini code review and make it efficient.

- Ignore the vendor directory from getting reviewed
- Comment severity threshold is set to MEDIUM so that the PR is spammed with lot of review comments
- Enable memory config is not already done in order to improve review comments.

reference:
https://docs.cloud.google.com/gemini/docs/code-review/customize-repo-review