### PR TITLE
Fix filestore Retrieve() failing when local cache directories are missing

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -215,7 +215,12 @@ func (fs *FileStore) Retrieve(ctx context.Context, path string) ([]byte, error) 
 		return nil, err
 	}
 
-	// write to local filesystem
+	// write to local filesystem — create parent directories if they don't exist
+	if dir := filepath.Dir(localPath); dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, err
+		}
+	}
 	err = os.WriteFile(localPath, data, 0644)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- `Retrieve()` downloads files from S3 when the local cache is empty, but `os.WriteFile` fails if the parent directory doesn't exist (e.g. after a PVC delete and pod restart)
- Adds `os.MkdirAll` before the write, matching what `Store()` already does
- Without this fix, all three pipeline stages (DocumentProcessor, ChunksGenerator, VectorEmbeddingsGenerator) enter a retry loop with ~12K errors because they can't write S3 data back to the local cache

## Test plan
- [ ] `go build ./pkg/filestore/` passes
- [ ] `go vet ./pkg/filestore/` passes
- [ ] Delete PVC, restart pod, verify controller recovers by re-downloading from S3