### PR TITLE
Add .gitattributes to collapse vendor/ in PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Collapse generated and vendored files in GitHub PR diffs
 vendor/** linguist-generated
 go.sum linguist-generated
+**/zz_generated.deepcopy.go linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Collapse generated and vendored files in GitHub PR diffs
+vendor/** linguist-generated
+go.sum linguist-generated


### PR DESCRIPTION
## Summary
- Adds a `.gitattributes` file that marks `vendor/**` and `go.sum` as `linguist-generated`
- This causes GitHub to automatically collapse these files in pull request diffs, making code reviews much easier to navigate
- Uses the bare `linguist-generated` syntax per the [official GitHub documentation](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)

## Why
The `vendor/` directory contains thousands of vendored dependency files. When a PR updates dependencies (`go mod vendor`), the diff is dominated by vendor changes, making it hard to review the actual code changes. With this `.gitattributes`, vendor files are collapsed by default in PR diffs (reviewers can still expand them with a click).

## References
- [GitHub docs: Customizing how changed files appear](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)
- [Linguist overrides documentation](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md)
- Used by [tektoncd/pipeline](https://github.com/tektoncd/pipeline/blob/main/.gitattributes), [openshift/console](https://github.com/openshift/console), [kubevirt/kubevirt](https://github.com/kubevirt/kubevirt), and others