### PR TITLE
Use MergeFrom status patch instead of Get-Update pattern

### DIFF
--- a/internal/controller/chunksgenerator_controller.go
+++ b/internal/controller/chunksgenerator_controller.go
@@ -95,13 +95,8 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// set status to waiting
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.ChunksGenerator{}
-		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-			return err
-		}
-		latest.SetWaiting()
-		return r.Status().Update(ctx, latest)
+	if err := controllerutils.StatusPatch(ctx, r.Client, chunksGeneratorCR, func() {
+		chunksGeneratorCR.SetWaiting()
 	}); err != nil {
 		logger.Error(err, "failed to update ChunksGenerator CR status")
 		return ctrl.Result{}, err
@@ -174,10 +169,10 @@ func (r *ChunksGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	successMessage := fmt.Sprintf("successfully reconciled chunks generator: %s", chunksGeneratorCR.Name)
-	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, chunksGeneratorKey, func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus(successMessage, nil)
+	if err := controllerutils.StatusPatch(ctx, r.Client, chunksGeneratorCR, func() {
+		chunksGeneratorCR.UpdateStatus(successMessage, nil)
 	}); err != nil {
-		logger.Error(err, "failed to update ChunksGenerator CR status", "namespace", chunksGeneratorKey.Namespace, "name", chunksGeneratorKey.Name)
+		logger.Error(err, "failed to update ChunksGenerator CR status", "namespace", chunksGeneratorCR.Namespace, "name", chunksGeneratorCR.Name)
 		return r.handleError(ctx, chunksGeneratorCR, err)
 	}
 	logger.Info("successfully updated ChunksGenerator CR status", "status", chunksGeneratorCR.Status)
@@ -369,9 +364,8 @@ func (r *ChunksGeneratorReconciler) handleError(ctx context.Context, chunksGener
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
-	chunksGeneratorKey := client.ObjectKeyFromObject(chunksGeneratorCR)
-	if updateErr := controllerutils.StatusUpdateWithRetry(ctx, r.Client, chunksGeneratorKey, func() client.Object { return &operatorv1alpha1.ChunksGenerator{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.ChunksGenerator).UpdateStatus("", reconcileErr)
+	if updateErr := controllerutils.StatusPatch(ctx, r.Client, chunksGeneratorCR, func() {
+		chunksGeneratorCR.UpdateStatus("", reconcileErr)
 	}); updateErr != nil {
 		logger.Error(updateErr, "failed to update ChunksGenerator CR status")
 		return ctrl.Result{}, updateErr

--- a/internal/controller/controllerconfig_controller.go
+++ b/internal/controller/controllerconfig_controller.go
@@ -194,8 +194,9 @@ func (r *ControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// update the status of the Config CR to indicate that it is healthy
-	config.UpdateStatus(nil)
-	if err := r.Status().Update(ctx, &config); err != nil {
+	if err := controllerutils.StatusPatch(ctx, r.Client, &config, func() {
+		config.UpdateStatus(nil)
+	}); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/controllerutils/conflict_retry.go
+++ b/internal/controller/controllerutils/conflict_retry.go
@@ -18,23 +18,21 @@ package controllerutils
 
 import (
 	"context"
+	"errors"
 
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// StatusUpdateWithRetry runs Get -> mutate -> Status().Update with RetryOnConflict.
-// newEmpty must return a new zero value of the object type (e.g. func() client.Object { return &ChunksGenerator{} }).
-// mutate is called with the fetched object so the caller can set status (e.g. SetWaiting(), UpdateStatus(msg, err)).
-func StatusUpdateWithRetry(ctx context.Context, c client.Client, key client.ObjectKey, newEmpty func() client.Object, mutate func(client.Object)) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		obj := newEmpty()
-		if err := c.Get(ctx, key, obj); err != nil {
-			return err
-		}
-		mutate(obj)
-		return c.Status().Update(ctx, obj)
-	})
+// StatusPatch snapshots the object, applies mutate, and patches only the status
+// diff via merge-patch. No re-fetch or conflict retry needed.
+func StatusPatch(ctx context.Context, c client.Client, obj client.Object, mutate func()) error {
+	base, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return errors.New("DeepCopyObject did not return a client.Object")
+	}
+	mutate()
+	return c.Status().Patch(ctx, obj, client.MergeFrom(base))
 }
 
 // RemoveForceReconcileLabelWithRetry gets the latest object, removes the force-reconcile label, and updates with retry.

--- a/internal/controller/documentprocessor_controller.go
+++ b/internal/controller/documentprocessor_controller.go
@@ -92,13 +92,8 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// set status to waiting
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.DocumentProcessor{}
-		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-			return err
-		}
-		latest.SetWaiting()
-		return r.Status().Update(ctx, latest)
+	if err := controllerutils.StatusPatch(ctx, r.Client, documentProcessorCR, func() {
+		documentProcessorCR.SetWaiting()
 	}); err != nil {
 		logger.Error(err, "failed to update DocumentProcessor CR status")
 		return ctrl.Result{}, err
@@ -171,13 +166,7 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return r.handleError(ctx, documentProcessorCR, errors.New("failed to process jobs or documents"))
 	}
 
-	latestDocumentProcessorCR := &operatorv1alpha1.DocumentProcessor{}
-	if err := r.Get(ctx, req.NamespacedName, latestDocumentProcessorCR); err != nil {
-		logger.Error(err, "failed to get DocumentProcessor CR")
-		return ctrl.Result{}, err
-	}
-
-	if len(latestDocumentProcessorCR.Status.Jobs) > 0 {
+	if len(documentProcessorCR.Status.Jobs) > 0 {
 		logger.Info("some jobs are still pending or running, will requeue after a bit ...")
 		return ctrl.Result{
 			RequeueAfter: requeueAfter,
@@ -186,19 +175,14 @@ func (r *DocumentProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	logger.Info("all jobs are completed, no need to requeue")
 
-	successMessage := fmt.Sprintf("successfully reconciled document processor: %s", latestDocumentProcessorCR.Name)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		res := &operatorv1alpha1.DocumentProcessor{}
-		if err := r.Get(ctx, documentProcessorKey, res); err != nil {
-			return err
-		}
-		res.UpdateStatus(successMessage, nil)
-		return r.Status().Update(ctx, res)
+	successMessage := fmt.Sprintf("successfully reconciled document processor: %s", documentProcessorCR.Name)
+	if err := controllerutils.StatusPatch(ctx, r.Client, documentProcessorCR, func() {
+		documentProcessorCR.UpdateStatus(successMessage, nil)
 	}); err != nil {
-		logger.Error(err, "failed to update DocumentProcessor CR status", "namespace", latestDocumentProcessorCR.Namespace, "name", latestDocumentProcessorCR.Name)
+		logger.Error(err, "failed to update DocumentProcessor CR status", "namespace", documentProcessorCR.Namespace, "name", documentProcessorCR.Name)
 		return r.handleError(ctx, documentProcessorCR, err)
 	}
-	logger.Info("successfully updated DocumentProcessor CR status", "status", latestDocumentProcessorCR.Status)
+	logger.Info("successfully updated DocumentProcessor CR status", "status", documentProcessorCR.Status)
 
 	return ctrl.Result{}, nil
 }
@@ -211,14 +195,8 @@ func (r *DocumentProcessorReconciler) reconcileJob(ctx context.Context, job oper
 			logger.Info("recovered from panic in processJob, likely stale job from previous session", "panic", panicErr, "taskID", job.TaskID, "filePath", job.FilePath)
 			if panicMessage, ok := panicErr.(string); ok && strings.Contains(panicMessage, docling.SemaphorePanicError) {
 				logger.Info("semaphore panic detected, removing stale job", "taskID", job.TaskID)
-				documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
-				if updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					latest := &operatorv1alpha1.DocumentProcessor{}
-					if getErr := r.Get(ctx, documentProcessorKey, latest); getErr != nil {
-						return getErr
-					}
-					latest.DeleteJobByFilePath(job.FilePath)
-					return r.Status().Update(ctx, latest)
+				if updateErr := controllerutils.StatusPatch(ctx, r.Client, documentProcessorCR, func() {
+					documentProcessorCR.DeleteJobByFilePath(job.FilePath)
 				}); updateErr != nil {
 					logger.Error(updateErr, "failed to delete stale job after panic", "filePath", job.FilePath)
 					err = updateErr
@@ -269,14 +247,8 @@ func (r *DocumentProcessorReconciler) reconcileJob(ctx context.Context, job oper
 		logger.Info("successfully stored the converted file in the filestore", "filePath", convertedFilePath)
 
 		// remove the job from the status as nothing needs to be done for this job
-		documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
-		if updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			latest := &operatorv1alpha1.DocumentProcessor{}
-			if getErr := r.Get(ctx, documentProcessorKey, latest); getErr != nil {
-				return getErr
-			}
-			latest.DeleteJobByFilePath(job.FilePath)
-			return r.Status().Update(ctx, latest)
+		if updateErr := controllerutils.StatusPatch(ctx, r.Client, documentProcessorCR, func() {
+			documentProcessorCR.DeleteJobByFilePath(job.FilePath)
 		}); updateErr != nil {
 			logger.Error(updateErr, "failed to delete job from status as it has completed successfully", "filePath", job.FilePath)
 			return updateErr
@@ -288,15 +260,9 @@ func (r *DocumentProcessorReconciler) reconcileJob(ctx context.Context, job oper
 		// if the attempts > max attempts, remove the job from the status
 		if job.Attempts >= maxDoclingConversionAttempts {
 			logger.Error(fmt.Errorf("failed to convert file, max attempts reached for file: %s", job.FilePath), "failed to convert file, max attempts reached")
-			documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
-			if updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				latest := &operatorv1alpha1.DocumentProcessor{}
-				if getErr := r.Get(ctx, documentProcessorKey, latest); getErr != nil {
-					return getErr
-				}
-				latest.AddPermanentlyFailingFile(job.FilePath)
-				latest.DeleteJobByFilePath(job.FilePath)
-				return r.Status().Update(ctx, latest)
+			if updateErr := controllerutils.StatusPatch(ctx, r.Client, documentProcessorCR, func() {
+				documentProcessorCR.AddPermanentlyFailingFile(job.FilePath)
+				documentProcessorCR.DeleteJobByFilePath(job.FilePath)
 			}); updateErr != nil {
 				logger.Error(updateErr, "failed to delete job from status as it has failed or skipped", "filePath", job.FilePath)
 				return updateErr
@@ -363,23 +329,17 @@ func (r *DocumentProcessorReconciler) processDocument(ctx context.Context, rawFi
 		conversionAttempt = job.Attempts + 1
 	}
 
-	documentProcessorKey := client.ObjectKey{Namespace: documentProcessorCR.Namespace, Name: documentProcessorCR.Name}
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.DocumentProcessor{}
-		if getErr := r.Get(ctx, documentProcessorKey, latest); getErr != nil {
-			return getErr
-		}
-		latest.AddOrUpdateJob(operatorv1alpha1.Job{
+	if err := controllerutils.StatusPatch(ctx, r.Client, documentProcessorCR, func() {
+		documentProcessorCR.AddOrUpdateJob(operatorv1alpha1.Job{
 			FilePath:          rawFilePath,
 			FileIdentifier:    fileUID,
 			DocumentConverter: string(unstructured.DocumentConverterDocling),
-			DoclingConfig:     latest.Spec.DocumentProcessorConfig.DoclingConfig,
+			DoclingConfig:     documentProcessorCR.Spec.DocumentProcessorConfig.DoclingConfig,
 			TaskID:            response.TaskID,
 			Status:            response.TaskStatus,
 			CreatedOn:         time.Now().Format(time.RFC3339),
 			Attempts:          conversionAttempt,
 		})
-		return r.Status().Update(ctx, latest)
 	}); err != nil {
 		logger.Error(err, "failed to update DocumentProcessor CR status")
 		return err
@@ -495,14 +455,8 @@ func (r *DocumentProcessorReconciler) needsConversion(ctx context.Context, rawFi
 		// if the current job is not valid (different configuration), then it is of no use to us irrespective of the status
 		// we will delete the job from status and create a new job with the new configuration
 		logger.Info("job already exists, but with a different configuration, let's delete the current job from status", "filePath", rawFilePath)
-		documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
-		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			latest := &operatorv1alpha1.DocumentProcessor{}
-			if getErr := r.Get(ctx, documentProcessorKey, latest); getErr != nil {
-				return getErr
-			}
-			latest.DeleteJobByFilePath(rawFilePath)
-			return r.Status().Update(ctx, latest)
+		if err := controllerutils.StatusPatch(ctx, r.Client, documentProcessorCR, func() {
+			documentProcessorCR.DeleteJobByFilePath(rawFilePath)
 		}); err != nil {
 			logger.Error(err, "failed to update DocumentProcessor CR status")
 			return false, err
@@ -546,17 +500,11 @@ func (r *DocumentProcessorReconciler) handleError(ctx context.Context, documentP
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
-	documentProcessorKey := client.ObjectKeyFromObject(documentProcessorCR)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.DocumentProcessor{}
-		if getErr := r.Get(ctx, documentProcessorKey, latest); getErr != nil {
-			return getErr
-		}
-		latest.UpdateStatus("", reconcileErr)
-		return r.Status().Update(ctx, latest)
-	}); err != nil {
-		logger.Error(err, "failed to update DocumentProcessor CR status")
-		return ctrl.Result{}, err
+	if updateErr := controllerutils.StatusPatch(ctx, r.Client, documentProcessorCR, func() {
+		documentProcessorCR.UpdateStatus("", reconcileErr)
+	}); updateErr != nil {
+		logger.Error(updateErr, "failed to update DocumentProcessor CR status")
+		return ctrl.Result{}, updateErr
 	}
 	return ctrl.Result{}, reconcileErr
 }

--- a/internal/controller/sqsinformer_controller.go
+++ b/internal/controller/sqsinformer_controller.go
@@ -176,8 +176,8 @@ func (r *SQSInformerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	sqsInformerKey := client.ObjectKeyFromObject(sqsInformerCR)
-	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, sqsInformerKey, func() client.Object { return &operatorv1alpha1.SQSInformer{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.SQSInformer).SetWaiting()
+	if err := controllerutils.StatusPatch(ctx, r.Client, sqsInformerCR, func() {
+		sqsInformerCR.SetWaiting()
 	}); err != nil {
 		logger.Error(err, "failed to update SQSInformer status")
 		return ctrl.Result{}, err
@@ -228,8 +228,8 @@ func (r *SQSInformerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	logger.Info("successfully processed all messages, will check again ...")
 	successMessage := "successfully processed all messages, will check again ..."
-	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, sqsInformerKey, func() client.Object { return &operatorv1alpha1.SQSInformer{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.SQSInformer).UpdateStatus(successMessage, nil)
+	if err := controllerutils.StatusPatch(ctx, r.Client, sqsInformerCR, func() {
+		sqsInformerCR.UpdateStatus(successMessage, nil)
 	}); err != nil {
 		logger.Error(err, "failed to update SQSInformer status")
 		return ctrl.Result{}, err
@@ -305,9 +305,8 @@ func (r *SQSInformerReconciler) handleError(ctx context.Context, sqsInformerCR *
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
-	sqsInformerKey := client.ObjectKeyFromObject(sqsInformerCR)
-	if updateErr := controllerutils.StatusUpdateWithRetry(ctx, r.Client, sqsInformerKey, func() client.Object { return &operatorv1alpha1.SQSInformer{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.SQSInformer).UpdateStatus("", reconcileErr)
+	if updateErr := controllerutils.StatusPatch(ctx, r.Client, sqsInformerCR, func() {
+		sqsInformerCR.UpdateStatus("", reconcileErr)
 	}); updateErr != nil {
 		logger.Error(updateErr, "failed to update SQSInformer status")
 		return ctrl.Result{}, updateErr

--- a/internal/controller/unstructureddatapipeline_controller.go
+++ b/internal/controller/unstructureddatapipeline_controller.go
@@ -89,13 +89,8 @@ func (r *UnstructuredDataPipelineReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, err
 	}
 
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.UnstructuredDataPipeline{}
-		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-			return err
-		}
-		latest.SetWaiting()
-		return r.Status().Update(ctx, latest)
+	if err := controllerutils.StatusPatch(ctx, r.Client, unstructuredDataPipelineCR, func() {
+		unstructuredDataPipelineCR.SetWaiting()
 	}); err != nil {
 		logger.Error(err, "failed to update UnstructuredDataPipeline CR status")
 		return ctrl.Result{}, err
@@ -279,10 +274,10 @@ func (r *UnstructuredDataPipelineReconciler) Reconcile(ctx context.Context, req 
 
 	// all done, let's update the status to ready
 	successMessage := fmt.Sprintf("successfully reconciled unstructured data product: %s", dataProductName)
-	if err := controllerutils.StatusUpdateWithRetry(ctx, r.Client, unstructuredDataPipelineKey, func() client.Object { return &operatorv1alpha1.UnstructuredDataPipeline{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.UnstructuredDataPipeline).UpdateStatus(successMessage, nil)
+	if err := controllerutils.StatusPatch(ctx, r.Client, unstructuredDataPipelineCR, func() {
+		unstructuredDataPipelineCR.UpdateStatus(successMessage, nil)
 	}); err != nil {
-		logger.Error(err, "failed to update UnstructuredDataPipeline CR status", "namespace", unstructuredDataPipelineKey.Namespace, "name", unstructuredDataPipelineKey.Name)
+		logger.Error(err, "failed to update UnstructuredDataPipeline CR status", "namespace", unstructuredDataPipelineCR.Namespace, "name", unstructuredDataPipelineCR.Name)
 		return r.handleError(ctx, unstructuredDataPipelineCR, err)
 	}
 	logger.Info("successfully updated UnstructuredDataPipeline CR status", "status", unstructuredDataPipelineCR.Status)
@@ -322,12 +317,11 @@ func (r *UnstructuredDataPipelineReconciler) handleError(ctx context.Context, un
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
-	unstructuredDataPipelineKey := client.ObjectKeyFromObject(unstructuredDataPipelineCR)
-	if updateErr := controllerutils.StatusUpdateWithRetry(ctx, r.Client, unstructuredDataPipelineKey, func() client.Object { return &operatorv1alpha1.UnstructuredDataPipeline{} }, func(obj client.Object) {
-		obj.(*operatorv1alpha1.UnstructuredDataPipeline).UpdateStatus("", reconcileErr)
+	if updateErr := controllerutils.StatusPatch(ctx, r.Client, unstructuredDataPipelineCR, func() {
+		unstructuredDataPipelineCR.UpdateStatus("", reconcileErr)
 	}); updateErr != nil {
 		logger.Error(updateErr, "failed to update UnstructuredDataPipeline CR status")
 		return ctrl.Result{}, updateErr
 	}
-	return ctrl.Result{}, err
+	return ctrl.Result{}, reconcileErr
 }

--- a/internal/controller/vectorembeddingsgenerator_controller.go
+++ b/internal/controller/vectorembeddingsgenerator_controller.go
@@ -78,13 +78,8 @@ func (r *VectorEmbeddingsGeneratorReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// set status to waiting
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.VectorEmbeddingsGenerator{}
-		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-			return err
-		}
-		latest.SetWaiting()
-		return r.Status().Update(ctx, latest)
+	if err := controllerutils.StatusPatch(ctx, r.Client, vectorEmbeddingsGeneratorCR, func() {
+		vectorEmbeddingsGeneratorCR.SetWaiting()
 	}); err != nil {
 		logger.Error(err, "failed to update VectorEmbeddingsGenerator CR status")
 		return ctrl.Result{}, err
@@ -165,16 +160,10 @@ func (r *VectorEmbeddingsGeneratorReconciler) Reconcile(ctx context.Context, req
 
 	// all done, let's update the status to ready
 	successMessage := fmt.Sprintf("successfully reconciled vector embeddings generator: %s", vectorEmbeddingsGeneratorCR.Name)
-	vectorEmbeddingsGeneratorKey := client.ObjectKeyFromObject(vectorEmbeddingsGeneratorCR)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		res := &operatorv1alpha1.VectorEmbeddingsGenerator{}
-		if err := r.Get(ctx, vectorEmbeddingsGeneratorKey, res); err != nil {
-			return err
-		}
-		res.UpdateStatus(successMessage, nil)
-		return r.Status().Update(ctx, res)
+	if err := controllerutils.StatusPatch(ctx, r.Client, vectorEmbeddingsGeneratorCR, func() {
+		vectorEmbeddingsGeneratorCR.UpdateStatus(successMessage, nil)
 	}); err != nil {
-		logger.Error(err, "failed to update VectorEmbeddingsGenerator CR status", "namespace", vectorEmbeddingsGeneratorKey.Namespace, "name", vectorEmbeddingsGeneratorKey.Name)
+		logger.Error(err, "failed to update VectorEmbeddingsGenerator CR status", "namespace", vectorEmbeddingsGeneratorCR.Namespace, "name", vectorEmbeddingsGeneratorCR.Name)
 		return r.handleError(ctx, vectorEmbeddingsGeneratorCR, err)
 	}
 	logger.Info("successfully updated VectorEmbeddingsGenerator CR status", "status", vectorEmbeddingsGeneratorCR.Status)
@@ -383,17 +372,11 @@ func (r *VectorEmbeddingsGeneratorReconciler) handleError(ctx context.Context, v
 	logger := log.FromContext(ctx)
 	logger.Error(err, "encountered error")
 	reconcileErr := err
-	key := client.ObjectKeyFromObject(vectorEmbeddingsGeneratorCR)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &operatorv1alpha1.VectorEmbeddingsGenerator{}
-		if getErr := r.Get(ctx, key, latest); getErr != nil {
-			return getErr
-		}
-		latest.UpdateStatus("", reconcileErr)
-		return r.Status().Update(ctx, latest)
-	}); err != nil {
-		logger.Error(err, "failed to update VectorEmbeddingsGenerator CR status")
-		return ctrl.Result{}, err
+	if updateErr := controllerutils.StatusPatch(ctx, r.Client, vectorEmbeddingsGeneratorCR, func() {
+		vectorEmbeddingsGeneratorCR.UpdateStatus("", reconcileErr)
+	}); updateErr != nil {
+		logger.Error(updateErr, "failed to update VectorEmbeddingsGenerator CR status")
+		return ctrl.Result{}, updateErr
 	}
 	return ctrl.Result{}, reconcileErr
 }


### PR DESCRIPTION
## Summary

- Replace `StatusUpdateWithRetry` (Get → mutate → `Status().Update` with `RetryOnConflict`) with a new `StatusPatch` helper that uses `client.MergeFrom` to compute and send only the status diff as a merge-patch
- Convert all 6 controllers (ChunksGenerator, SQSInformer, UnstructuredDataPipeline, DocumentProcessor, VectorEmbeddingsGenerator, ControllerConfig) — every inline `retry.RetryOnConflict` status-update block and every `StatusUpdateWithRetry` call site
- Net **−83 lines** by eliminating re-fetch boilerplate (`Get` + `latest` variables + `ObjectKeyFromObject`) at every status update site

## Why

The existing Get → mutate → `Status().Update` pattern:
1. Re-fetches the entire object from the API server on every status update, even though the controller already has the object in memory
2. Replaces the *entire* status subresource, increasing the chance of write conflicts
3. Requires `RetryOnConflict` wrapping to handle those conflicts

`Status().Patch` with `client.MergeFrom`:
1. Uses the in-memory object directly — no extra API round-trip
2. Sends only the changed status fields as a JSON merge-patch
3. No conflict retry needed since the patch doesn't carry `resourceVersion` in the diff body

## Test plan

- [x] `make build` passes
- [x] `make lint` passes (0 issues)
- [x] `go vet` passes
- [x] Verified zero remaining occurrences of `StatusUpdateWithRetry` or `Status().Update` in controller code