### PR TITLE
Add required description field to UnstructuredDataPipeline

### DIFF
--- a/api/v1alpha1/unstructureddatapipeline_types.go
+++ b/api/v1alpha1/unstructureddatapipeline_types.go
@@ -216,7 +216,9 @@ type NomicEmbedTextV15Config struct {
 
 // UnstructuredDataPipelineSpec defines the desired state of UnstructuredDataPipeline
 type UnstructuredDataPipelineSpec struct {
+	// Description is a human-readable summary of what the pipeline does.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	Description string `json:"description"`
 	// +optional
 	SecretRef string `json:"secretRef,omitempty"`

--- a/api/v1alpha1/unstructureddatapipeline_types.go
+++ b/api/v1alpha1/unstructureddatapipeline_types.go
@@ -216,6 +216,8 @@ type NomicEmbedTextV15Config struct {
 
 // UnstructuredDataPipelineSpec defines the desired state of UnstructuredDataPipeline
 type UnstructuredDataPipelineSpec struct {
+	// +kubebuilder:validation:Required
+	Description string `json:"description"`
 	// +optional
 	SecretRef string `json:"secretRef,omitempty"`
 	// +kubebuilder:validation:MinItems=1

--- a/config/crd/bases/operator.dataverse.redhat.com_unstructureddatapipelines.yaml
+++ b/config/crd/bases/operator.dataverse.redhat.com_unstructureddatapipelines.yaml
@@ -49,6 +49,9 @@ spec:
               UnstructuredDataPipeline
             properties:
               description:
+                description: Description is a human-readable summary of what the pipeline
+                  does.
+                minLength: 1
                 type: string
               secretRef:
                 type: string

--- a/config/crd/bases/operator.dataverse.redhat.com_unstructureddatapipelines.yaml
+++ b/config/crd/bases/operator.dataverse.redhat.com_unstructureddatapipelines.yaml
@@ -48,6 +48,8 @@ spec:
             description: UnstructuredDataPipelineSpec defines the desired state of
               UnstructuredDataPipeline
             properties:
+              description:
+                type: string
               secretRef:
                 type: string
               stages:
@@ -244,6 +246,7 @@ spec:
                 - name
                 x-kubernetes-list-type: map
             required:
+            - description
             - stages
             type: object
           status:

--- a/config/samples/operator_v1alpha1_unstructureddatapipeline.yaml
+++ b/config/samples/operator_v1alpha1_unstructureddatapipeline.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: my-pipeline
 spec:
+  description: "Sample pipeline that crawls documents from S3, converts to Markdown, chunks, generates embeddings, and syncs to destination S3"
   secretRef: pipeline-secret
   stages:
     - name: crawl

--- a/test/utils/utils_function.go
+++ b/test/utils/utils_function.go
@@ -48,6 +48,7 @@ func GetUnstructuredDataPipelineResourceWithStage(name, namespace string) v1alph
 			},
 		},
 		Spec: v1alpha1.UnstructuredDataPipelineSpec{
+			Description: "e2e test pipeline",
 			Stages: []v1alpha1.PipelineStage{
 				{
 					Name: "crawl",


### PR DESCRIPTION
## Summary
- Adds a required `description` string field to `UnstructuredDataPipelineSpec` so users can provide a human-readable summary of what the pipeline does
- Regenerates CRD manifests with `description` as a required field
- Updates the sample CR and docs with example description values

## Test plan
- [x] `make build` passes
- [x] `make lint` passes (0 issues)
- [x] Unit tests pass
- [x] CRD correctly lists `description` as required