### PR TITLE
Switch e2e workflow to auto-run without manual approval

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -5,7 +5,7 @@ on:
     branches: [main, release-*]
     tags:
       - "v*"
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -23,16 +23,14 @@ jobs:
   build-and-push:
     name: Build Container Image
     runs-on: ubuntu-latest
-    environment: e2e-tests
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout base
+      - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Determine image tag
         id: image-tag
@@ -119,7 +117,6 @@ jobs:
   test-e2e:
     name: Run E2E Tests
     runs-on: ubuntu-latest
-    environment: e2e-tests
     needs: build-and-push
     permissions:
       contents: read
@@ -128,8 +125,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -69,15 +69,14 @@ jobs:
   build-and-push-mcp:
     name: Build MCP Server Image
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout base
+      - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Determine image tag
         id: image-tag


### PR DESCRIPTION
## Summary

- Switch `pull_request_target` → `pull_request` trigger so e2e CI runs automatically on PRs from org members without the manual "Approve and deploy" click
- Remove `environment: e2e-tests` gate from both jobs (no longer needed)
- Remove explicit `ref:` checkout of PR head SHA (the `pull_request` trigger defaults to the merge commit, which is correct and safe)
- Add fork guard (`if:` condition) to skip image build for fork PRs

## Why

The `pull_request_target` + `environment: e2e-tests` combination required a member of `unstructured-data-controller-admin` to manually click "Approve and deploy" on **every single push** to a PR. This was necessary because `pull_request_target` checks out untrusted fork code with full secret access (the ["pwn request" vulnerability](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)).

Switching to `pull_request` eliminates this entire attack class — fork PRs get read-only tokens and no secrets by GitHub's design. The repo's existing setting ("Require approval for all external contributors") ensures non-org contributors still need approval before workflows run.

Additionally, `actions/checkout@v6` will [backport the `pull_request_target` fork checkout block](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/) on July 16, 2026, which would break the current workflow.

## Security posture

| Actor | Before | After |
|-------|--------|-------|
| Org members | Manual click per push | Auto-runs, no clicks |
| External contributors | Manual click per push | "Approve and run" click (GitHub setting), then auto-runs with read-only token, no secrets |
| Fork PR secret access | Available (gated by environment approval) | **None** (GitHub's built-in boundary) |

## Post-merge cleanup

Optionally delete the `e2e-tests` environment in Settings > Environments — it's no longer referenced.

## Test plan

- [ ] Verify org member PR triggers e2e without manual approval
- [ ] Verify fork PR skips build-and-push and test-e2e jobs
- [ ] Verify build/lint/unit test workflows are unaffected