### PR TITLE
Add logging and let agent auto-resolve snowflake target from pipeline description

### DIFF
--- a/cmd/unstructured-data-mcp-server/main.go
+++ b/cmd/unstructured-data-mcp-server/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/embedding"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/k8sclient"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/logger"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -42,11 +43,8 @@ const (
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
-	slog.SetDefault(logger)
-	ctrl.SetLogger(logr.FromSlogHandler(logger.Handler()))
+	logger.Init()
+	ctrl.SetLogger(logr.FromSlogHandler(slog.Default().Handler()))
 
 	oauthCfg, err := auth.NewOAuthConfigFromEnv()
 	if err != nil {
@@ -86,8 +84,8 @@ func main() {
 	mcptools.RegisterGetChunksForEmbeddings(mcpServer, embeddingClient)
 
 	oauthStore := auth.NewOAuthStore()
-	oauthMiddleware := auth.NewMiddleware(provider, logger)
-	oauthServer := auth.NewOAuthServer(provider, oauthCfg.CallbackURL, oauthStore, logger)
+	oauthMiddleware := auth.NewMiddleware(provider, slog.Default())
+	oauthServer := auth.NewOAuthServer(provider, oauthCfg.CallbackURL, oauthStore, slog.Default())
 
 	mcpHandler := mcp.NewStreamableHTTPHandler(
 		func(_ *http.Request) *mcp.Server { return mcpServer },

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -166,11 +166,57 @@ The full authorization flow follows the [MCP Authorization specification (2025-1
 | `GET`                   | `/healthz`                                | None         | Liveness probe                           |
 | `GET`                   | `/readyz`                                 | None         | Readiness probe                          |
 
+## Tools
+
+### `list_unstructured_data_pipelines_for_user`
+
+Lists all UnstructuredDataPipeline custom resources and Snowflake databases the authenticated user has access to.
+
+**Parameters:** None (uses OAuth token from context).
+
+**Returns:** A combined JSON result containing:
+
+- `pipelines` — array of pipelines with:
+  - `name` — pipeline CR name
+  - `namespace` — Kubernetes namespace
+  - `description` — human-readable summary of what the pipeline does
+  - `database` — Snowflake database name (from the stage's `queryConfig`, if set)
+  - `schema` — Snowflake schema name (from the stage's `queryConfig`, if set)
+  - `table` — Snowflake table name (from the stage's `queryConfig`, if set)
+  - `status` — pipeline readiness status
+  - `message` — status message
+- `databases` — array of Snowflake databases accessible to the user
+
+### `get_chunks_for_embeddings`
+
+Searches for relevant text chunks in a data product using vector cosine similarity. Returns the top 5 matching chunks for the given query.
+
+**Parameters:**
+
+| Parameter      | Required | Description                                                                                                                                   |
+| -------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `udp_database` | Yes      | Name of the data product database. If not known, call `list_unstructured_data_pipelines_for_user` first and pick the matching pipeline.       |
+| `schema`       | Yes      | Snowflake schema name. If not known, call `list_unstructured_data_pipelines_for_user` first.                                                  |
+| `table`        | Yes      | Snowflake table name. If not known, call `list_unstructured_data_pipelines_for_user` first.                                                   |
+| `query`        | Yes      | The search query to find relevant chunks.                                                                                                     |
+
+**Typical agent flow:**
+
+1. User asks a question (no database specified).
+2. Agent calls `list_unstructured_data_pipelines_for_user` to get pipeline descriptions, database names, schemas, and tables.
+3. Agent matches the user's question to a pipeline based on its description.
+4. If confident, agent calls `get_chunks_for_embeddings` with the resolved `udp_database`, `schema`, and `table`.
+5. If ambiguous (multiple pipelines could match), agent asks the user to clarify.
+
 ## Package Structure
 
 ```
 cmd/unstructured-data-mcp-server/
   main.go                  ← entry point, wiring
+
+internal/mcp/tools/
+  list_pipelines.go        ← list_unstructured_data_pipelines_for_user tool
+  get_chunks.go            ← get_chunks_for_embeddings tool
 
 pkg/auth/
   provider.go              ← Provider interface (extensible)

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/embedding"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/logger"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/snowflake"
 )
 
@@ -45,10 +46,17 @@ If udp_database, schema, or table are not known, call list_unstructured_data_pip
 On error: report the exact error to the user and STOP. Do NOT retry with other pipelines or databases.
 On follow-up: if the user is not satisfied, ask them which pipeline to search. Do NOT automatically try other pipelines.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getChunksArgs) (*mcp.CallToolResult, any, error) {
-		slog.Info("get_chunks: tool invoked", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table)
+		username := ""
+		if tokenInfo, ok := auth.TokenInfoFromContext(ctx); ok {
+			username = tokenInfo.Username
+		}
+		ctx = logger.NewContext(ctx, uuid.NewString(), "get_chunks_for_embeddings", username)
+		log := logger.FromContext(ctx)
+
+		log.Info("tool invoked", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table)
 
 		if args.UDPDatabase == "" || args.Schema == "" || args.Table == "" || args.Query == "" {
-			slog.Error("get_chunks: missing required parameters", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table, "query_empty", args.Query == "")
+			log.Error("missing required parameters", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table, "query_empty", args.Query == "")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: udp_database, schema, table, and query are required. Call list_unstructured_data_pipelines_for_user first to get the database, schema, and table values."}},
 				IsError: true,
@@ -57,41 +65,41 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 
 		oauthToken, ok := auth.AccessTokenFromContext(ctx)
 		if !ok {
-			slog.Error("get_chunks: OAuth token not found in context")
+			log.Error("oauth token not found in context")
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: "Error: OAuth token not found in context"}},
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: oauth token not found in context"}},
 				IsError: true,
 			}, nil, nil
 		}
 
-		slog.Info("get_chunks: generating embedding for query")
+		log.Info("generating embedding for query")
 		result, err := embeddingClient.GenerateEmbeddings(ctx, []string{args.Query}, "float")
 		if err != nil {
-			slog.Error("get_chunks: failed to generate embedding", "error", err)
+			log.Error("failed to generate embedding", "error", err)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error generating embedding: %v", err)}},
 				IsError: true,
 			}, nil, nil
 		}
 
-		if result.Count == 0 || len(result.Embeddings) == 0 {
-			slog.Error("get_chunks: embedding API returned no vectors")
+		if result == nil || result.Count == 0 || len(result.Embeddings) == 0 {
+			log.Error("embedding API returned no vectors")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: embedding API returned no vectors"}},
 				IsError: true,
 			}, nil, nil
 		}
-		slog.Info("get_chunks: embedding generated", "vector_dimensions", len(result.Embeddings[0]))
+		log.Info("embedding generated", "vector_dimensions", len(result.Embeddings[0]))
 
 		vectorLiteral := formatVectorLiteral(result.Embeddings[0])
 		databaseName := strings.ToUpper(strings.ReplaceAll(args.UDPDatabase, "-", "_"))
 		schemaName := strings.ToUpper(args.Schema)
 		tableName := strings.ToUpper(args.Table)
 
-		slog.Info("get_chunks: searching snowflake", "database", databaseName, "schema", schemaName, "table", tableName)
+		log.Info("searching snowflake", "database", databaseName, "schema", schemaName, "table", tableName)
 		chunks, err := snowflake.SearchChunks(ctx, oauthToken, databaseName, schemaName, tableName, vectorLiteral)
 		if err != nil {
-			slog.Error("get_chunks: failed to search chunks in snowflake", "error", err, "database", databaseName, "schema", schemaName, "table", tableName)
+			log.Error("failed to search chunks in snowflake", "error", err, "database", databaseName, "schema", schemaName, "table", tableName)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error searching chunks: %v", err)}},
 				IsError: true,
@@ -100,14 +108,14 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 
 		jsonBytes, err := json.Marshal(chunks)
 		if err != nil {
-			slog.Error("get_chunks: failed to marshal result", "error", err)
+			log.Error("failed to marshal result", "error", err)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error marshaling result: %v", err)}},
 				IsError: true,
 			}, nil, nil
 		}
 
-		slog.Info("get_chunks: completed successfully", "database", databaseName, "chunks_found", len(chunks))
+		log.Info("completed successfully", "database", databaseName, "chunks_found", len(chunks))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
 				Text: fmt.Sprintf("Found %d chunks for query in %s.%s.%s:\n%s", len(chunks), databaseName, schemaName, tableName, string(jsonBytes)),

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -30,32 +31,43 @@ import (
 )
 
 type getChunksArgs struct {
-	UDPDatabase string `json:"udp_database" jsonschema:"Name of the data product database"`
+	UDPDatabase string `json:"udp_database" jsonschema:"Name of the data product database. If not known, call list_unstructured_data_pipelines_for_user first and pick the matching pipeline based on its description."`
+	Schema      string `json:"schema" jsonschema:"Snowflake schema name. If not known, call list_unstructured_data_pipelines_for_user first."`
+	Table       string `json:"table" jsonschema:"Snowflake table name. If not known, call list_unstructured_data_pipelines_for_user first."`
 	Query       string `json:"query" jsonschema:"The search query to find relevant chunks"`
 }
 
 func RegisterGetChunksForEmbeddings(s *mcp.Server, embeddingClient *embedding.HTTPClient) {
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_chunks_for_embeddings",
-		Description: "Search for relevant text chunks in a data product using vector cosine similarity. Returns top 5 matching chunks for the given query.",
+		Name: "get_chunks_for_embeddings",
+		Description: `Search for relevant text chunks in a data product using vector cosine similarity. Returns top 5 matching chunks for the given query.
+If udp_database, schema, or table are not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
+On error: report the exact error to the user and STOP. Do NOT retry with other pipelines or databases.
+On follow-up: if the user is not satisfied, ask them which pipeline to search. Do NOT automatically try other pipelines.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getChunksArgs) (*mcp.CallToolResult, any, error) {
-		if args.UDPDatabase == "" || args.Query == "" {
+		slog.Info("get_chunks: tool invoked", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table)
+
+		if args.UDPDatabase == "" || args.Schema == "" || args.Table == "" || args.Query == "" {
+			slog.Error("get_chunks: missing required parameters", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table, "query_empty", args.Query == "")
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: "Error: udp_database and query are required"}},
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: udp_database, schema, table, and query are required. Call list_unstructured_data_pipelines_for_user first to get the database, schema, and table values."}},
 				IsError: true,
 			}, nil, nil
 		}
 
 		oauthToken, ok := auth.AccessTokenFromContext(ctx)
 		if !ok {
+			slog.Error("get_chunks: OAuth token not found in context")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: OAuth token not found in context"}},
 				IsError: true,
 			}, nil, nil
 		}
 
+		slog.Info("get_chunks: generating embedding for query")
 		result, err := embeddingClient.GenerateEmbeddings(ctx, []string{args.Query}, "float")
 		if err != nil {
+			slog.Error("get_chunks: failed to generate embedding", "error", err)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error generating embedding: %v", err)}},
 				IsError: true,
@@ -63,17 +75,23 @@ func RegisterGetChunksForEmbeddings(s *mcp.Server, embeddingClient *embedding.HT
 		}
 
 		if result.Count == 0 || len(result.Embeddings) == 0 {
+			slog.Error("get_chunks: embedding API returned no vectors")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: embedding API returned no vectors"}},
 				IsError: true,
 			}, nil, nil
 		}
+		slog.Info("get_chunks: embedding generated", "vector_dimensions", len(result.Embeddings[0]))
 
 		vectorLiteral := formatVectorLiteral(result.Embeddings[0])
 		databaseName := strings.ToUpper(strings.ReplaceAll(args.UDPDatabase, "-", "_"))
+		schemaName := strings.ToUpper(args.Schema)
+		tableName := strings.ToUpper(args.Table)
 
-		chunks, err := snowflake.SearchChunks(ctx, oauthToken, databaseName, "MARTS", "CHUNKS_WITH_EMBEDDINGS", vectorLiteral)
+		slog.Info("get_chunks: searching snowflake", "database", databaseName, "schema", schemaName, "table", tableName)
+		chunks, err := snowflake.SearchChunks(ctx, oauthToken, databaseName, schemaName, tableName, vectorLiteral)
 		if err != nil {
+			slog.Error("get_chunks: failed to search chunks in snowflake", "error", err, "database", databaseName, "schema", schemaName, "table", tableName)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error searching chunks: %v", err)}},
 				IsError: true,
@@ -82,15 +100,17 @@ func RegisterGetChunksForEmbeddings(s *mcp.Server, embeddingClient *embedding.HT
 
 		jsonBytes, err := json.Marshal(chunks)
 		if err != nil {
+			slog.Error("get_chunks: failed to marshal result", "error", err)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error marshaling result: %v", err)}},
 				IsError: true,
 			}, nil, nil
 		}
 
+		slog.Info("get_chunks: completed successfully", "database", databaseName, "chunks_found", len(chunks))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Found %d chunks for query in %s.MARTS:\n%s", len(chunks), databaseName, string(jsonBytes)),
+				Text: fmt.Sprintf("Found %d chunks for query in %s.%s.%s:\n%s", len(chunks), databaseName, schemaName, tableName, string(jsonBytes)),
 			}},
 		}, nil, nil
 	})

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
+	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/k8sclient"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/logger"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/snowflake"
 )
 
@@ -40,25 +41,32 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 		Name:        "list_unstructured_data_pipelines_for_user",
 		Description: "List all UnstructuredDataPipeline custom resources and Snowflake databases the authenticated user has access to.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
-		slog.Info("list_pipelines: tool invoked")
+		username := ""
+		if tokenInfo, ok := auth.TokenInfoFromContext(ctx); ok {
+			username = tokenInfo.Username
+		}
+		ctx = logger.NewContext(ctx, uuid.NewString(), "list_unstructured_data_pipelines_for_user", username)
+		log := logger.FromContext(ctx)
+
+		log.Info("tool invoked")
 
 		oauthToken, ok := auth.AccessTokenFromContext(ctx)
 		if !ok {
-			slog.Error("list_pipelines: OAuth token not found in context")
+			log.Error("oauth token not found in context")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
-					Text: "Error: OAuth token not found in context",
+					Text: "Error: oauth token not found in context",
 				}},
 				IsError: true,
 			}, nil, nil
 		}
 
-		var pipelines []k8sclient.PipelineInfo
+		pipelines := []k8sclient.PipelineInfo{}
 		if k8sClient != nil {
 			var err error
 			pipelines, err = k8sClient.ListPipelines(ctx)
 			if err != nil {
-				slog.Error("list_pipelines: failed to list pipelines from kubernetes", "error", err)
+				log.Error("failed to list pipelines from kubernetes", "error", err)
 				return &mcp.CallToolResult{
 					Content: []mcp.Content{&mcp.TextContent{
 						Text: fmt.Sprintf("Error listing pipelines: %v", err),
@@ -66,14 +74,14 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 					IsError: true,
 				}, nil, nil
 			}
-			slog.Info("list_pipelines: listed pipelines from kubernetes", "count", len(pipelines))
+			log.Info("listed pipelines from kubernetes", "count", len(pipelines))
 		} else {
-			slog.Warn("list_pipelines: kubernetes client is nil, skipping pipeline listing")
+			log.Warn("kubernetes client is nil, skipping pipeline listing")
 		}
 
 		databases, err := snowflake.ShowDatabases(ctx, oauthToken)
 		if err != nil {
-			slog.Error("list_pipelines: failed to list databases from snowflake", "error", err)
+			log.Error("failed to list databases from snowflake", "error", err)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
 					Text: fmt.Sprintf("Error querying Snowflake: %v", err),
@@ -81,7 +89,7 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 				IsError: true,
 			}, nil, nil
 		}
-		slog.Info("list_pipelines: listed databases from snowflake", "count", len(databases))
+		log.Info("listed databases from snowflake", "count", len(databases))
 
 		result := CombinedResult{
 			Pipelines: pipelines,
@@ -90,7 +98,7 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 
 		jsonBytes, err := json.Marshal(result)
 		if err != nil {
-			slog.Error("list_pipelines: failed to marshal result", "error", err)
+			log.Error("failed to marshal result", "error", err)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
 					Text: fmt.Sprintf("Error marshaling result: %v", err),
@@ -99,7 +107,7 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 			}, nil, nil
 		}
 
-		slog.Info("list_pipelines: completed successfully", "pipelines", len(pipelines), "databases", len(databases))
+		log.Info("completed successfully", "pipelines", len(pipelines), "databases", len(databases))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
 				Text: fmt.Sprintf("Found %d pipeline(s) and %d database(s):\n%s\n\n"+

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
@@ -37,11 +38,13 @@ type CombinedResult struct {
 func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_unstructured_data_pipelines_for_user",
-		Description: "List all UnstructuredDataPipeline custom resources and Snowflake databases the authenticated user has access to",
+		Description: "List all UnstructuredDataPipeline custom resources and Snowflake databases the authenticated user has access to.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
-		// Extract OAuth token from context
+		slog.Info("list_pipelines: tool invoked")
+
 		oauthToken, ok := auth.AccessTokenFromContext(ctx)
 		if !ok {
+			slog.Error("list_pipelines: OAuth token not found in context")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
 					Text: "Error: OAuth token not found in context",
@@ -50,12 +53,12 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 			}, nil, nil
 		}
 
-		// List Kubernetes UnstructuredDataPipeline CRs
 		var pipelines []k8sclient.PipelineInfo
 		if k8sClient != nil {
 			var err error
 			pipelines, err = k8sClient.ListPipelines(ctx)
 			if err != nil {
+				slog.Error("list_pipelines: failed to list pipelines from kubernetes", "error", err)
 				return &mcp.CallToolResult{
 					Content: []mcp.Content{&mcp.TextContent{
 						Text: fmt.Sprintf("Error listing pipelines: %v", err),
@@ -63,11 +66,14 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 					IsError: true,
 				}, nil, nil
 			}
+			slog.Info("list_pipelines: listed pipelines from kubernetes", "count", len(pipelines))
+		} else {
+			slog.Warn("list_pipelines: kubernetes client is nil, skipping pipeline listing")
 		}
 
-		// Query Snowflake databases using the user's OAuth token
 		databases, err := snowflake.ShowDatabases(ctx, oauthToken)
 		if err != nil {
+			slog.Error("list_pipelines: failed to list databases from snowflake", "error", err)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
 					Text: fmt.Sprintf("Error querying Snowflake: %v", err),
@@ -75,8 +81,8 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 				IsError: true,
 			}, nil, nil
 		}
+		slog.Info("list_pipelines: listed databases from snowflake", "count", len(databases))
 
-		// Combine results
 		result := CombinedResult{
 			Pipelines: pipelines,
 			Databases: databases,
@@ -84,6 +90,7 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 
 		jsonBytes, err := json.Marshal(result)
 		if err != nil {
+			slog.Error("list_pipelines: failed to marshal result", "error", err)
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
 					Text: fmt.Sprintf("Error marshaling result: %v", err),
@@ -92,9 +99,14 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 			}, nil, nil
 		}
 
+		slog.Info("list_pipelines: completed successfully", "pipelines", len(pipelines), "databases", len(databases))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Found %d pipeline(s) and %d database(s):\n%s",
+				Text: fmt.Sprintf("Found %d pipeline(s) and %d database(s):\n%s\n\n"+
+					"IMPORTANT: If you are selecting a pipeline for a search query, you MUST follow these rules:\n"+
+					"- If EXACTLY ONE pipeline matches the user's question, use it.\n"+
+					"- If MORE THAN ONE pipeline could match, STOP and ask the user which one to use. Do NOT pick one yourself.\n"+
+					"- If NONE match, tell the user. Do NOT try all pipelines.",
 					len(pipelines), len(databases), string(jsonBytes)),
 			}},
 		}, nil, nil

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -28,10 +28,14 @@ import (
 const defaultPipelineNamespace = "unstructured-controller-namespace"
 
 type PipelineInfo struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Status    string `json:"status,omitempty"`
-	Message   string `json:"message,omitempty"`
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	Description string `json:"description"`
+	Database    string `json:"database,omitempty"`
+	Schema      string `json:"schema,omitempty"`
+	Table       string `json:"table,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Message     string `json:"message,omitempty"`
 }
 
 func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
@@ -52,8 +56,18 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	result := make([]PipelineInfo, len(pipelineList.Items))
 	for i, pipeline := range pipelineList.Items {
 		info := PipelineInfo{
-			Name:      pipeline.Name,
-			Namespace: pipeline.Namespace,
+			Name:        pipeline.Name,
+			Namespace:   pipeline.Namespace,
+			Description: pipeline.Spec.Description,
+		}
+
+		for _, stage := range pipeline.Spec.Stages {
+			if stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
+				info.Database = stage.QueryConfig.Snowflake.Database
+				info.Schema = stage.QueryConfig.Snowflake.Schema
+				info.Table = stage.QueryConfig.Snowflake.Table
+				break
+			}
 		}
 
 		for _, condition := range pipeline.Status.Conditions {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+type contextKey string
+
+const loggerKey contextKey = "logger_ctx"
+
+// Init configures the default slog logger with JSON output to stdout.
+func Init() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+}
+
+// NewContext returns a new context with a logger that includes request_id, tool_name, and username.
+func NewContext(ctx context.Context, requestID, toolName, username string) context.Context {
+	l := slog.Default().With(
+		"request_id", requestID,
+		"tool_name", toolName,
+		"username", username,
+	)
+	return context.WithValue(ctx, loggerKey, l)
+}
+
+// FromContext extracts the logger from context. Falls back to slog.Default() if not set.
+func FromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(loggerKey).(*slog.Logger); ok {
+		return l
+	}
+	return slog.Default()
+}


### PR DESCRIPTION
… description

- enrich PipelineInfo with description, database, schema, and table from queryConfig
  - add schema and table params to get_chunks, remove hardcoded MARTS/CHUNKS_WITH_EMBEDDINGS
  - add structured slog logging across both mcp tools for debugging
  - document tools section and agent flow in docs/mcp-server.md