### PR TITLE
Use global Google client for group membership resolution

### DIFF
--- a/config/samples/unstructured-secret.yaml
+++ b/config/samples/unstructured-secret.yaml
@@ -12,6 +12,17 @@ stringData:
   FILE_STORE_AWS_ENDPOINT: http://localhost:4566
   EMBEDDING_ENDPOINT: "http://localhost:11434/v1/embeddings"
   EMBEDDING_API_KEY: ""
+  CONTROLLER_GOOGLE_SERVICE_ACCOUNT_JSON: |
+    {
+      "type": "service_account",
+      "project_id": "your-project-id",
+      "private_key_id": "key-id",
+      "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+      "client_email": "sa@your-project.iam.gserviceaccount.com",
+      "client_id": "123456789",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token"
+    }
 ---
 # Pipeline-level secret for source and destination AWS credentials
 apiVersion: v1

--- a/config/samples/unstructured-secret.yaml
+++ b/config/samples/unstructured-secret.yaml
@@ -12,7 +12,7 @@ stringData:
   FILE_STORE_AWS_ENDPOINT: http://localhost:4566
   EMBEDDING_ENDPOINT: "http://localhost:11434/v1/embeddings"
   EMBEDDING_API_KEY: ""
-  CONTROLLER_GOOGLE_SERVICE_ACCOUNT_JSON: |
+  GROUPS_READER_GOOGLE_SERVICE_ACCOUNT_JSON: |
     {
       "type": "service_account",
       "project_id": "your-project-id",

--- a/internal/controller/controllerconfig_controller.go
+++ b/internal/controller/controllerconfig_controller.go
@@ -35,6 +35,7 @@ import (
 	pkgcache "github.com/redhat-data-and-ai/unstructured-data-controller/pkg/cache"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/cache/inmemory"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/docling"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/gdrive/google"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/gdrive/ldap"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/langchain"
 )
@@ -48,6 +49,7 @@ var (
 	LDAPClient                             ldap.Client
 	CacheClient                            pkgcache.Cache
 	GoogleDriveControllerCfg               *operatorv1alpha1.GoogleDriveControllerConfig
+	GlobalGoogleClient                     google.GoogleClient
 )
 
 // ControllerConfigReconciler reconciles a ControllerConfig object
@@ -149,6 +151,16 @@ func (r *ControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	GoogleDriveControllerCfg = config.Spec.GoogleDriveConfig
+
+	if credJSON := secret.Data["CONTROLLER_GOOGLE_SERVICE_ACCOUNT_JSON"]; len(credJSON) > 0 {
+		globalClient, err := google.NewClientFromJSON(ctx, credJSON)
+		if err != nil {
+			logger.Error(err, "failed to create global Google client for group resolution")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+		GlobalGoogleClient = globalClient
+		logger.Info("Global Google client initialized for group membership resolution")
+	}
 
 	if config.Spec.UnstructuredDataPipelineResyncInterval != nil {
 		UnstructuredDataPipelineResyncInterval = config.Spec.UnstructuredDataPipelineResyncInterval

--- a/internal/controller/controllerconfig_controller.go
+++ b/internal/controller/controllerconfig_controller.go
@@ -152,7 +152,7 @@ func (r *ControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	GoogleDriveControllerCfg = config.Spec.GoogleDriveConfig
 
-	if credJSON := secret.Data["CONTROLLER_GOOGLE_SERVICE_ACCOUNT_JSON"]; len(credJSON) > 0 {
+	if credJSON, ok := secret.Data["GROUPS_READER_GOOGLE_SERVICE_ACCOUNT_JSON"]; ok {
 		globalClient, err := google.NewClientFromJSON(ctx, credJSON)
 		if err != nil {
 			logger.Error(err, "failed to create global Google client for group resolution")

--- a/internal/controller/sourcecrawler_controller.go
+++ b/internal/controller/sourcecrawler_controller.go
@@ -221,7 +221,7 @@ func (r *SourceCrawlerReconciler) buildGDriveSource(
 		return nil, errors.New("cache client not initialized in ControllerConfig")
 	}
 
-	gdriveClient, err := gdrive.NewClient(googleClient, LDAPClient, CacheClient)
+	gdriveClient, err := gdrive.NewClient(googleClient, GlobalGoogleClient, LDAPClient, CacheClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gdrive client: %w", err)
 	}

--- a/internal/controller/sourcecrawler_controller.go
+++ b/internal/controller/sourcecrawler_controller.go
@@ -221,6 +221,10 @@ func (r *SourceCrawlerReconciler) buildGDriveSource(
 		return nil, errors.New("cache client not initialized in ControllerConfig")
 	}
 
+	if GlobalGoogleClient == nil {
+		return nil, errors.New("global Google client for group resolution not initialized in ControllerConfig")
+	}
+
 	gdriveClient, err := gdrive.NewClient(googleClient, GlobalGoogleClient, LDAPClient, CacheClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gdrive client: %w", err)

--- a/pkg/gdrive/client.go
+++ b/pkg/gdrive/client.go
@@ -27,25 +27,28 @@ import (
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/gdrive/ldap"
 )
 
-// Client wraps Google Drive, LDAP, and cache clients to provide
+// Client wraps Controller-GoogleClient, Google Drive, LDAP, and cache clients to provide
 // folder crawling and permission resolution functionality.
 type Client struct {
-	googleClient google.GoogleClient
-	ldapClient   ldap.Client
-	cacheClient  cache.Cache
-	groupFlight  singleflight.Group
+	globalGoogleClient google.GoogleClient
+	googleClient       google.GoogleClient
+	ldapClient         ldap.Client
+	cacheClient        cache.Cache
+	groupFlight        singleflight.Group
 }
 
 // NewClient creates a new gdrive Client with the provided dependencies.
 func NewClient(
 	googleClient google.GoogleClient,
+	globalGoogleClient google.GoogleClient,
 	ldapClient ldap.Client,
 	cacheClient cache.Cache,
 ) (*Client, error) {
 	return &Client{
-		googleClient: googleClient,
-		ldapClient:   ldapClient,
-		cacheClient:  cacheClient,
+		globalGoogleClient: globalGoogleClient,
+		googleClient:       googleClient,
+		ldapClient:         ldapClient,
+		cacheClient:        cacheClient,
 	}, nil
 }
 

--- a/pkg/gdrive/orchestrator.go
+++ b/pkg/gdrive/orchestrator.go
@@ -150,7 +150,7 @@ func (o *Orchestrator) processFileIDs(
 	}
 
 	client, err := NewClient(
-		googleClient, ldapClient, cacheClient)
+		googleClient, nil, ldapClient, cacheClient)
 	if err != nil {
 		return fmt.Errorf(
 			"failed to create Drive client: %w", err)
@@ -194,7 +194,7 @@ func (o *Orchestrator) processFolderIDs(
 	}
 
 	client, err := NewClient(
-		googleClient, ldapClient, cacheClient)
+		googleClient, nil, ldapClient, cacheClient)
 	if err != nil {
 		return fmt.Errorf(
 			"failed to create Drive client: %w", err)

--- a/pkg/gdrive/permissions.go
+++ b/pkg/gdrive/permissions.go
@@ -138,8 +138,11 @@ func (c *Client) GetFilePermissions(
 							}
 						}
 
-						// Fetch from API
-						members, err := c.googleClient.GetGroupMembers(
+						groupClient := c.googleClient
+						if c.globalGoogleClient != nil {
+							groupClient = c.globalGoogleClient
+						}
+						members, err := groupClient.GetGroupMembers(
 							ctx, p.EmailAddress)
 						if err != nil {
 							return nil, err

--- a/pkg/gdrive/permissions.go
+++ b/pkg/gdrive/permissions.go
@@ -138,11 +138,7 @@ func (c *Client) GetFilePermissions(
 							}
 						}
 
-						groupClient := c.googleClient
-						if c.globalGoogleClient != nil {
-							groupClient = c.globalGoogleClient
-						}
-						members, err := groupClient.GetGroupMembers(
+						members, err := c.globalGoogleClient.GetGroupMembers(
 							ctx, p.EmailAddress)
 						if err != nil {
 							return nil, err


### PR DESCRIPTION
  Group membership lookups via Cloud Identity API are not
  per-pipeline — they use a shared controller-level service account
  (CONTROLLER_GOOGLE_SERVICE_ACCOUNT_JSON) instead of individual
  pipeline credentials. Falls back to the per-pipeline client when
  the global client is not configured