### PR TITLE
Set PIPELINE_NAMESPACE via downward API in MCP server deployment

### DIFF
--- a/config/mcp/deployment.yaml
+++ b/config/mcp/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           protocol: TCP
 
         env:
-        - name: PIPELINE_NAMESPACE
+        - name: UNSTRUCTURED_DATA_CONTROLLER_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/config/mcp/deployment.yaml
+++ b/config/mcp/deployment.yaml
@@ -34,6 +34,12 @@ spec:
           containerPort: 8080
           protocol: TCP
 
+        env:
+        - name: PIPELINE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+
         envFrom:
         - configMapRef:
             name: unstructured-data-mcp-server-config

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -41,7 +41,7 @@ type PipelineInfo struct {
 func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	pipelineList := &operatorv1alpha1.UnstructuredDataPipelineList{}
 
-	namespace := os.Getenv("PIPELINE_NAMESPACE")
+	namespace := os.Getenv("UNSTRUCTURED_DATA_CONTROLLER_NAMESPACE")
 	if namespace == "" {
 		namespace = defaultPipelineNamespace
 	}


### PR DESCRIPTION
## Summary
- The MCP server was getting 403 Forbidden when listing pipelines because `PIPELINE_NAMESPACE` was not set, causing it to default to `unstructured-controller-namespace` which doesn't match the actual deployment namespace
- Injects the pod's own namespace via the Kubernetes downward API so `PIPELINE_NAMESPACE` always matches the deployment namespace automatically

## Test plan
- [ ] Deploy the updated MCP server and verify `list_unstructured_data_pipelines_for_user` no longer returns a 403
- [ ] Verify the `PIPELINE_NAMESPACE` env var is correctly set to the pod's namespace