### PR TITLE
Separate source and destination credentials in pipeline secret

### DIFF
--- a/config/samples/unstructured-secret.yaml
+++ b/config/samples/unstructured-secret.yaml
@@ -13,18 +13,20 @@ stringData:
   EMBEDDING_ENDPOINT: "http://localhost:11434/v1/embeddings"
   EMBEDDING_API_KEY: ""
 ---
-# Pipeline-level secret for source and destination AWS credentials
+# Pipeline-level secret for source and destination credentials
 apiVersion: v1
 kind: Secret
 metadata:
   name: pipeline-secret
 type: Opaque
 stringData:
-  AWS_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: test
-  AWS_SECRET_ACCESS_KEY: test
-  AWS_ENDPOINT: http://localhost:4566
-  GOOGLE_SERVICE_ACCOUNT_JSON: |
+  # Source S3 credentials
+  SOURCE_S3_REGION: us-east-1
+  SOURCE_S3_ACCESS_KEY_ID: test
+  SOURCE_S3_SECRET_ACCESS_KEY: test
+  SOURCE_S3_ENDPOINT: http://localhost:4566
+  # Source Google Drive credentials
+  SOURCE_GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON: |
     {
       "type": "service_account",
       "project_id": "your-project-id",
@@ -35,3 +37,8 @@ stringData:
       "auth_uri": "https://accounts.google.com/o/oauth2/auth",
       "token_uri": "https://oauth2.googleapis.com/token"
     }
+  # Destination S3 credentials
+  DESTINATION_S3_REGION: us-east-1
+  DESTINATION_S3_ACCESS_KEY_ID: test
+  DESTINATION_S3_SECRET_ACCESS_KEY: test
+  DESTINATION_S3_ENDPOINT: http://localhost:4566

--- a/internal/controller/controllerutils/secret_helpers.go
+++ b/internal/controller/controllerutils/secret_helpers.go
@@ -39,7 +39,10 @@ func ParentPipelineNameFromOwnerReference(obj client.Object) (string, error) {
 }
 
 // AWSConfigFromSecret reads a K8s secret and returns an AWSConfig.
-func AWSConfigFromSecret(ctx context.Context, c client.Client, secretName, namespace string) (*awsclienthandler.AWSConfig, error) {
+// The prefix selects which set of keys to read (e.g. "SOURCE_S3_" or
+// "DESTINATION_S3_"), so the same secret can carry separate credentials
+// for source and destination.
+func AWSConfigFromSecret(ctx context.Context, c client.Client, secretName, namespace, prefix string) (*awsclienthandler.AWSConfig, error) {
 	if secretName == "" {
 		return &awsclienthandler.AWSConfig{}, nil
 	}
@@ -48,17 +51,17 @@ func AWSConfigFromSecret(ctx context.Context, c client.Client, secretName, names
 		return nil, fmt.Errorf("failed to fetch secret %s: %w", secretName, err)
 	}
 	return &awsclienthandler.AWSConfig{
-		Region:          string(secret.Data["AWS_REGION"]),
-		AccessKeyID:     string(secret.Data["AWS_ACCESS_KEY_ID"]),
-		SecretAccessKey: string(secret.Data["AWS_SECRET_ACCESS_KEY"]),
-		SessionToken:    string(secret.Data["AWS_SESSION_TOKEN"]),
-		Endpoint:        string(secret.Data["AWS_ENDPOINT"]),
+		Region:          string(secret.Data[prefix+"REGION"]),
+		AccessKeyID:     string(secret.Data[prefix+"ACCESS_KEY_ID"]),
+		SecretAccessKey: string(secret.Data[prefix+"SECRET_ACCESS_KEY"]),
+		SessionToken:    string(secret.Data[prefix+"SESSION_TOKEN"]),
+		Endpoint:        string(secret.Data[prefix+"ENDPOINT"]),
 	}, nil
 }
 
 // GDriveCredentialsFromSecret reads the Google service account JSON
 // from a K8s Secret. The secret must contain a key named
-// "GOOGLE_SERVICE_ACCOUNT_JSON".
+// "SOURCE_GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON".
 func GDriveCredentialsFromSecret(ctx context.Context, c client.Client, secretName, namespace string) ([]byte, error) {
 	if secretName == "" {
 		return nil, errors.New("secretRef is required for gdrive source type")
@@ -67,9 +70,10 @@ func GDriveCredentialsFromSecret(ctx context.Context, c client.Client, secretNam
 	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
 		return nil, fmt.Errorf("failed to fetch secret %s: %w", secretName, err)
 	}
-	credentialsJSON, ok := secret.Data["GOOGLE_SERVICE_ACCOUNT_JSON"]
+	const key = "SOURCE_GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON"
+	credentialsJSON, ok := secret.Data[key]
 	if !ok || len(credentialsJSON) == 0 {
-		return nil, fmt.Errorf("secret %s does not contain key GOOGLE_SERVICE_ACCOUNT_JSON", secretName)
+		return nil, fmt.Errorf("secret %s does not contain key %s", secretName, key)
 	}
 	return credentialsJSON, nil
 }

--- a/internal/controller/destinationsyncer_controller.go
+++ b/internal/controller/destinationsyncer_controller.go
@@ -101,7 +101,7 @@ func (r *DestinationSyncerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if destConfig.Type != operatorv1alpha1.TypeS3 {
 		return r.handleError(ctx, destinationSyncCR, fmt.Errorf("unsupported destination type: %s", destConfig.Type))
 	}
-	awsConfig, err := controllerutils.AWSConfigFromSecret(ctx, r.Client, destinationSyncCR.Spec.SecretRef, destinationSyncCR.Namespace)
+	awsConfig, err := controllerutils.AWSConfigFromSecret(ctx, r.Client, destinationSyncCR.Spec.SecretRef, destinationSyncCR.Namespace, "DESTINATION_S3_")
 	if err != nil {
 		return r.handleError(ctx, destinationSyncCR, fmt.Errorf("failed to get destination S3 credentials: %w", err))
 	}

--- a/internal/controller/sourcecrawler_controller.go
+++ b/internal/controller/sourcecrawler_controller.go
@@ -108,7 +108,7 @@ func (r *SourceCrawlerReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	var source unstructured.DataSource
 	switch sourceCrawlerConfig.Type {
 	case operatorv1alpha1.TypeS3:
-		sourceAWSConfig, err := controllerutils.AWSConfigFromSecret(ctx, r.Client, sourceCrawlerCR.Spec.SecretRef, sourceCrawlerCR.Namespace)
+		sourceAWSConfig, err := controllerutils.AWSConfigFromSecret(ctx, r.Client, sourceCrawlerCR.Spec.SecretRef, sourceCrawlerCR.Namespace, "SOURCE_S3_")
 		if err != nil {
 			return ctrl.Result{}, r.handleError(ctx, sourceCrawlerCR, fmt.Errorf("failed to get source credentials: %w", err))
 		}

--- a/test/resources/unstructured/unstructured-secret.yaml
+++ b/test/resources/unstructured/unstructured-secret.yaml
@@ -13,14 +13,20 @@ stringData:
   EMBEDDING_ENDPOINT: http://ollama-embedding:11434/v1/embeddings
   EMBEDDING_API_KEY: "ollama"
 ---
-# Pipeline-level secret for source and destination AWS credentials
+# Pipeline-level secret for source and destination credentials
 apiVersion: v1
 kind: Secret
 metadata:
   name: pipeline-secret
 type: Opaque
 stringData:
-  AWS_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: LSIAQAAAAAAVNCBMPNSG
-  AWS_SECRET_ACCESS_KEY: LSIAQAAAAAAVNCBMPNSG
-  AWS_ENDPOINT: http://localstack:4566
+  # Source S3 credentials
+  SOURCE_S3_REGION: us-east-1
+  SOURCE_S3_ACCESS_KEY_ID: LSIAQAAAAAAVNCBMPNSG
+  SOURCE_S3_SECRET_ACCESS_KEY: LSIAQAAAAAAVNCBMPNSG
+  SOURCE_S3_ENDPOINT: http://localstack:4566
+  # Destination S3 credentials
+  DESTINATION_S3_REGION: us-east-1
+  DESTINATION_S3_ACCESS_KEY_ID: LSIAQAAAAAAVNCBMPNSG
+  DESTINATION_S3_SECRET_ACCESS_KEY: LSIAQAAAAAAVNCBMPNSG
+  DESTINATION_S3_ENDPOINT: http://localstack:4566


### PR DESCRIPTION
## Summary
- The pipeline `secretRef` previously used shared `AWS_*` keys for both source and destination, making it impossible to use different credentials for each
- Source keys are now prefixed with `SOURCE_S3_*` (and `SOURCE_GOOGLE_DRIVE_*` for GDrive)
- Destination keys are now prefixed with `DESTINATION_S3_*`
- `AWSConfigFromSecret()` takes a `prefix` parameter so the same secret can carry separate credentials

## Test plan
- [ ] Verify `make test` passes (unit tests pass, `covdata` tool error is pre-existing)
- [ ] Deploy with a pipeline secret containing separate `SOURCE_S3_*` and `DESTINATION_S3_*` credentials
- [ ] Verify source crawler reads from the source S3 using `SOURCE_S3_*` creds
- [ ] Verify destination syncer writes to the destination S3 using `DESTINATION_S3_*` creds
- [ ] Verify Google Drive source uses `SOURCE_GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON`