### PR TITLE
Sort files by size (smallest first) before processing

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -264,6 +265,10 @@ func (fs *FileStore) ListFilesInPath(ctx context.Context, path string) ([]string
 	if err != nil {
 		return nil, err
 	}
+
+	sort.Slice(objects, func(i, j int) bool {
+		return *objects[i].Size < *objects[j].Size
+	})
 
 	files := []string{}
 	for _, object := range objects {

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -267,7 +267,14 @@ func (fs *FileStore) ListFilesInPath(ctx context.Context, path string) ([]string
 	}
 
 	sort.Slice(objects, func(i, j int) bool {
-		return *objects[i].Size < *objects[j].Size
+		var sizeI, sizeJ int64
+		if objects[i].Size != nil {
+			sizeI = *objects[i].Size
+		}
+		if objects[j].Size != nil {
+			sizeJ = *objects[j].Size
+		}
+		return sizeI < sizeJ
 	})
 
 	files := []string{}

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -268,14 +268,7 @@ func (fs *FileStore) ListFilesInPath(ctx context.Context, path string) ([]string
 	}
 
 	slices.SortStableFunc(objects, func(a, b s3types.Object) int {
-		var sizeA, sizeB int64
-		if a.Size != nil {
-			sizeA = *a.Size
-		}
-		if b.Size != nil {
-			sizeB = *b.Size
-		}
-		return cmp.Compare(sizeA, sizeB)
+		return cmp.Compare(aws.ToInt64(a.Size), aws.ToInt64(b.Size))
 	})
 
 	files := []string{}

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -18,13 +18,14 @@ package filestore
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -266,15 +267,15 @@ func (fs *FileStore) ListFilesInPath(ctx context.Context, path string) ([]string
 		return nil, err
 	}
 
-	sort.Slice(objects, func(i, j int) bool {
-		var sizeI, sizeJ int64
-		if objects[i].Size != nil {
-			sizeI = *objects[i].Size
+	slices.SortStableFunc(objects, func(a, b s3types.Object) int {
+		var sizeA, sizeB int64
+		if a.Size != nil {
+			sizeA = *a.Size
 		}
-		if objects[j].Size != nil {
-			sizeJ = *objects[j].Size
+		if b.Size != nil {
+			sizeB = *b.Size
 		}
-		return sizeI < sizeJ
+		return cmp.Compare(sizeA, sizeB)
 	})
 
 	files := []string{}


### PR DESCRIPTION
## Summary
- Sorts S3 objects by size in ascending order in `ListFilesInPath` so that all downstream controllers (DocumentProcessor, ChunksGenerator, VectorEmbeddingsGenerator, DestinationSyncer) process smallest files first
- Smaller files complete quickly, improving perceived progress while larger files are deferred

## Test plan
- [x] `go build ./...` passes
- [x] Unit tests pass
- [x] Deploy and verify files are processed in size order via controller logs