### PR TITLE
Return the VectorEmbeddings table name during list

### DIFF
--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -62,7 +62,8 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 		}
 
 		for _, stage := range pipeline.Spec.Stages {
-			if stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
+			if stage.Type == operatorv1alpha1.StageTypeVectorEmbeddingsGenerator &&
+				stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
 				info.Database = stage.QueryConfig.Snowflake.Database
 				info.Schema = stage.QueryConfig.Snowflake.Schema
 				info.Table = stage.QueryConfig.Snowflake.Table


### PR DESCRIPTION
At the moment the list_unstructured_data_pipelines_for_user tool returns the first item that comes in the list instead it should return the name of table related to VectorEmbeddingsGenerator