### PR TITLE
Simplify MCP tools: get_chunks takes pipeline name, resolves table internally

### DIFF
--- a/cmd/unstructured-data-mcp-server/main.go
+++ b/cmd/unstructured-data-mcp-server/main.go
@@ -81,7 +81,7 @@ func main() {
 	})
 
 	mcptools.RegisterListPipelines(mcpServer, k8sClient)
-	mcptools.RegisterGetChunksForEmbeddings(mcpServer, embeddingClient)
+	mcptools.RegisterGetChunksForEmbeddings(mcpServer, k8sClient, embeddingClient)
 
 	oauthStore := auth.NewOAuthStore()
 	oauthMiddleware := auth.NewMiddleware(provider, slog.Default())

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -88,6 +88,14 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			}, nil, nil
 		}
 
+		if qc.Database == "" || qc.Schema == "" || qc.Table == "" {
+			log.Error("pipeline query config has empty fields", "database", qc.Database, "schema", qc.Schema, "table", qc.Table)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error: pipeline %q has incomplete Snowflake query configuration", args.PipelineName)}},
+				IsError: true,
+			}, nil, nil
+		}
+
 		log.Info("generating embedding for query")
 		result, err := embeddingClient.GenerateEmbeddings(ctx, []string{args.Query}, "float")
 		if err != nil {

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -27,23 +27,22 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/embedding"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/k8sclient"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/logger"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/snowflake"
 )
 
 type getChunksArgs struct {
-	UDPDatabase string `json:"udp_database" jsonschema:"Name of the data product database. If not known, call list_unstructured_data_pipelines_for_user first and pick the matching pipeline based on its description."`
-	Schema      string `json:"schema" jsonschema:"Snowflake schema name. If not known, call list_unstructured_data_pipelines_for_user first."`
-	Table       string `json:"table" jsonschema:"Snowflake table name. If not known, call list_unstructured_data_pipelines_for_user first."`
-	Query       string `json:"query" jsonschema:"The search query to find relevant chunks"`
+	PipelineName string `json:"pipeline_name" jsonschema:"Name of the UnstructuredDataPipeline. If not known, call list_unstructured_data_pipelines_for_user first and pick the matching pipeline based on its description."`
+	Query        string `json:"query" jsonschema:"The search query to find relevant chunks"`
 }
 
-func RegisterGetChunksForEmbeddings(s *mcp.Server, embeddingClient *embedding.HTTPClient) {
+func RegisterGetChunksForEmbeddings(s *mcp.Server, k8sClient *k8sclient.Client, embeddingClient *embedding.HTTPClient) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name: "get_chunks_for_embeddings",
-		Description: `Search for relevant text chunks in a data product using vector cosine similarity. Returns top 5 matching chunks for the given query.
-If udp_database, schema, or table are not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
-On error: report the exact error to the user and STOP. Do NOT retry with other pipelines or databases.
+		Description: `Search for relevant text chunks in a pipeline's data product using vector cosine similarity. Returns top 5 matching chunks for the given query.
+If pipeline_name is not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
+On error: report the exact error to the user and STOP. Do NOT retry with other pipelines.
 On follow-up: if the user is not satisfied, ask them which pipeline to search. Do NOT automatically try other pipelines.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getChunksArgs) (*mcp.CallToolResult, any, error) {
 		username := ""
@@ -53,12 +52,12 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		ctx = logger.NewContext(ctx, uuid.NewString(), "get_chunks_for_embeddings", username)
 		log := logger.FromContext(ctx)
 
-		log.Info("tool invoked", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table)
+		log.Info("tool invoked", "pipeline_name", args.PipelineName)
 
-		if args.UDPDatabase == "" || args.Schema == "" || args.Table == "" || args.Query == "" {
-			log.Error("missing required parameters", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table, "query_empty", args.Query == "")
+		if args.PipelineName == "" || args.Query == "" {
+			log.Error("missing required parameters", "pipeline_name", args.PipelineName, "query_empty", args.Query == "")
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: "Error: udp_database, schema, table, and query are required. Call list_unstructured_data_pipelines_for_user first to get the database, schema, and table values."}},
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: pipeline_name and query are required. Call list_unstructured_data_pipelines_for_user first to get the pipeline name."}},
 				IsError: true,
 			}, nil, nil
 		}
@@ -68,6 +67,15 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			log.Error("oauth token not found in context")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: oauth token not found in context"}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName)
+		if err != nil {
+			log.Error("failed to get pipeline query config", "error", err)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error resolving pipeline %q: %v", args.PipelineName, err)}},
 				IsError: true,
 			}, nil, nil
 		}
@@ -92,9 +100,9 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		log.Info("embedding generated", "vector_dimensions", len(result.Embeddings[0]))
 
 		vectorLiteral := formatVectorLiteral(result.Embeddings[0])
-		databaseName := strings.ToUpper(strings.ReplaceAll(args.UDPDatabase, "-", "_"))
-		schemaName := strings.ToUpper(args.Schema)
-		tableName := strings.ToUpper(args.Table)
+		databaseName := strings.ToUpper(strings.ReplaceAll(qc.Database, "-", "_"))
+		schemaName := strings.ToUpper(qc.Schema)
+		tableName := strings.ToUpper(qc.Table)
 
 		log.Info("searching snowflake", "database", databaseName, "schema", schemaName, "table", tableName)
 		chunks, err := snowflake.SearchChunks(ctx, oauthToken, databaseName, schemaName, tableName, vectorLiteral)
@@ -115,7 +123,7 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			}, nil, nil
 		}
 
-		log.Info("completed successfully", "database", databaseName, "chunks_found", len(chunks))
+		log.Info("completed successfully", "pipeline", args.PipelineName, "chunks_found", len(chunks))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
 				Text: fmt.Sprintf("Found %d chunks for query in %s.%s.%s:\n%s", len(chunks), databaseName, schemaName, tableName, string(jsonBytes)),

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -134,7 +134,7 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		log.Info("completed successfully", "pipeline", args.PipelineName, "chunks_found", len(chunks))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Found %d chunks for query in %s.%s.%s:\n%s", len(chunks), databaseName, schemaName, tableName, string(jsonBytes)),
+				Text: fmt.Sprintf("Found %d chunks for query in pipeline %q:\n%s", len(chunks), args.PipelineName, string(jsonBytes)),
 			}},
 		}, nil, nil
 	})

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -71,6 +71,14 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			}, nil, nil
 		}
 
+		if k8sClient == nil {
+			log.Error("kubernetes client is nil")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: kubernetes client is not initialized"}},
+				IsError: true,
+			}, nil, nil
+		}
+
 		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName)
 		if err != nil {
 			log.Error("failed to get pipeline query config", "error", err)

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -94,7 +94,7 @@ If NONE match, tell the user. Do NOT try all pipelines.`,
 			userDBs[strings.ToUpper(db.Name)] = true
 		}
 
-		var accessible []k8sclient.PipelineInfo
+		accessible := []k8sclient.PipelineInfo{}
 		for _, p := range pipelines {
 			if p.Database != "" && userDBs[strings.ToUpper(p.Database)] {
 				accessible = append(accessible, p)

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -96,11 +96,7 @@ If NONE match, tell the user. Do NOT try all pipelines.`,
 
 		var accessible []k8sclient.PipelineInfo
 		for _, p := range pipelines {
-			db, err := k8sClient.GetPipelineDatabase(ctx, p.Name)
-			if err != nil {
-				continue
-			}
-			if userDBs[strings.ToUpper(db)] {
+			if p.Database != "" && userDBs[strings.ToUpper(p.Database)] {
 				accessible = append(accessible, p)
 			}
 		}

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -96,7 +96,8 @@ If NONE match, tell the user. Do NOT try all pipelines.`,
 
 		accessible := []k8sclient.PipelineInfo{}
 		for _, p := range pipelines {
-			if p.Database != "" && userDBs[strings.ToUpper(p.Database)] {
+			dbKey := strings.ToUpper(strings.ReplaceAll(p.Database, "-", "_"))
+			if p.Database != "" && userDBs[dbKey] {
 				accessible = append(accessible, p)
 			}
 		}

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -33,8 +33,11 @@ import (
 // RegisterListPipelines registers the list_unstructured_data_pipelines_for_user MCP tool
 func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "list_unstructured_data_pipelines_for_user",
-		Description: "List all UnstructuredDataPipeline custom resources and Snowflake databases the authenticated user has access to.",
+		Name: "list_unstructured_data_pipelines_for_user",
+		Description: `List the UnstructuredDataPipelines the authenticated user has access to. Returns an array of {name, description}.
+If EXACTLY ONE pipeline matches the user's question, use it.
+If MORE THAN ONE pipeline could match, STOP and ask the user which one to use. Do NOT pick one yourself.
+If NONE match, tell the user. Do NOT try all pipelines.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		username := ""
 		if tokenInfo, ok := auth.TokenInfoFromContext(ctx); ok {
@@ -74,15 +77,6 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 			log.Warn("kubernetes client is nil, skipping pipeline listing")
 		}
 
-		// Build map of pipeline database names to pipeline info
-		pipelinesByDB := make(map[string][]k8sclient.PipelineInfo, len(pipelines))
-		for _, p := range pipelines {
-			if p.Database != "" {
-				dbKey := strings.ToUpper(p.Database)
-				pipelinesByDB[dbKey] = append(pipelinesByDB[dbKey], p)
-			}
-		}
-
 		databases, err := snowflake.ShowDatabases(ctx, oauthToken)
 		if err != nil {
 			log.Error("failed to list databases from snowflake", "error", err)
@@ -95,16 +89,19 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 		}
 		log.Info("listed databases from snowflake", "count", len(databases))
 
-		// Intersect: keep only pipelines whose database the user has access to
 		userDBs := make(map[string]bool, len(databases))
 		for _, db := range databases {
 			userDBs[strings.ToUpper(db.Name)] = true
 		}
 
 		var accessible []k8sclient.PipelineInfo
-		for dbName, plist := range pipelinesByDB {
-			if userDBs[dbName] {
-				accessible = append(accessible, plist...)
+		for _, p := range pipelines {
+			db, err := k8sClient.GetPipelineDatabase(ctx, p.Name)
+			if err != nil {
+				continue
+			}
+			if userDBs[strings.ToUpper(db)] {
+				accessible = append(accessible, p)
 			}
 		}
 
@@ -122,12 +119,7 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 		log.Info("completed successfully", "total_pipelines", len(pipelines), "accessible_pipelines", len(accessible))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Found %d accessible pipeline(s):\n%s\n\n"+
-					"IMPORTANT: If you are selecting a pipeline for a search query, you MUST follow these rules:\n"+
-					"- If EXACTLY ONE pipeline matches the user's question, use it.\n"+
-					"- If MORE THAN ONE pipeline could match, STOP and ask the user which one to use. Do NOT pick one yourself.\n"+
-					"- If NONE match, tell the user. Do NOT try all pipelines.",
-					len(accessible), string(jsonBytes)),
+				Text: string(jsonBytes),
 			}},
 		}, nil, nil
 	})

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -30,6 +30,7 @@ const defaultPipelineNamespace = "unstructured-controller-namespace"
 type PipelineInfo struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Database    string `json:"-"`
 }
 
 type QueryConfig struct {
@@ -71,30 +72,18 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 
 	result := make([]PipelineInfo, len(pipelineList.Items))
 	for i, pipeline := range pipelineList.Items {
+		var db string
+		if qc := snowflakeQueryConfig(&pipeline); qc != nil {
+			db = qc.Database
+		}
 		result[i] = PipelineInfo{
 			Name:        pipeline.Name,
 			Description: pipeline.Spec.Description,
+			Database:    db,
 		}
 	}
 
 	return result, nil
-}
-
-func (c *Client) GetPipelineDatabase(ctx context.Context, name string) (string, error) {
-	pipeline := &operatorv1alpha1.UnstructuredDataPipeline{}
-	err := c.client.Get(ctx, client.ObjectKey{
-		Namespace: pipelineNamespace(),
-		Name:      name,
-	}, pipeline)
-	if err != nil {
-		return "", fmt.Errorf("failed to get pipeline %q: %w", name, err)
-	}
-
-	qc := snowflakeQueryConfig(pipeline)
-	if qc == nil {
-		return "", fmt.Errorf("pipeline %q has no Snowflake query config", name)
-	}
-	return qc.Database, nil
 }
 
 func (c *Client) GetPipelineQueryConfig(ctx context.Context, name string) (*QueryConfig, error) {

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -29,25 +29,41 @@ const defaultPipelineNamespace = "unstructured-controller-namespace"
 
 type PipelineInfo struct {
 	Name        string `json:"name"`
-	Namespace   string `json:"namespace"`
 	Description string `json:"description"`
-	Database    string `json:"database,omitempty"`
-	Schema      string `json:"schema,omitempty"`
-	Table       string `json:"table,omitempty"`
-	Status      string `json:"status,omitempty"`
-	Message     string `json:"message,omitempty"`
+}
+
+type QueryConfig struct {
+	Database string
+	Schema   string
+	Table    string
+}
+
+func pipelineNamespace() string {
+	if ns := os.Getenv("UNSTRUCTURED_DATA_CONTROLLER_NAMESPACE"); ns != "" {
+		return ns
+	}
+	return defaultPipelineNamespace
+}
+
+func snowflakeQueryConfig(pipeline *operatorv1alpha1.UnstructuredDataPipeline) *QueryConfig {
+	for _, stage := range pipeline.Spec.Stages {
+		if stage.Type == operatorv1alpha1.StageTypeVectorEmbeddingsGenerator &&
+			stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
+			return &QueryConfig{
+				Database: stage.QueryConfig.Snowflake.Database,
+				Schema:   stage.QueryConfig.Snowflake.Schema,
+				Table:    stage.QueryConfig.Snowflake.Table,
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	pipelineList := &operatorv1alpha1.UnstructuredDataPipelineList{}
 
-	namespace := os.Getenv("UNSTRUCTURED_DATA_CONTROLLER_NAMESPACE")
-	if namespace == "" {
-		namespace = defaultPipelineNamespace
-	}
-
 	err := c.client.List(ctx, pipelineList, &client.ListOptions{
-		Namespace: namespace,
+		Namespace: pipelineNamespace(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pipelines: %w", err)
@@ -55,32 +71,45 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 
 	result := make([]PipelineInfo, len(pipelineList.Items))
 	for i, pipeline := range pipelineList.Items {
-		info := PipelineInfo{
+		result[i] = PipelineInfo{
 			Name:        pipeline.Name,
-			Namespace:   pipeline.Namespace,
 			Description: pipeline.Spec.Description,
 		}
-
-		for _, stage := range pipeline.Spec.Stages {
-			if stage.Type == operatorv1alpha1.StageTypeVectorEmbeddingsGenerator &&
-				stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
-				info.Database = stage.QueryConfig.Snowflake.Database
-				info.Schema = stage.QueryConfig.Snowflake.Schema
-				info.Table = stage.QueryConfig.Snowflake.Table
-				break
-			}
-		}
-
-		for _, condition := range pipeline.Status.Conditions {
-			if condition.Type == "UnstructuredDataPipelineReady" {
-				info.Status = string(condition.Status)
-				info.Message = condition.Message
-				break
-			}
-		}
-
-		result[i] = info
 	}
 
 	return result, nil
+}
+
+func (c *Client) GetPipelineDatabase(ctx context.Context, name string) (string, error) {
+	pipeline := &operatorv1alpha1.UnstructuredDataPipeline{}
+	err := c.client.Get(ctx, client.ObjectKey{
+		Namespace: pipelineNamespace(),
+		Name:      name,
+	}, pipeline)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pipeline %q: %w", name, err)
+	}
+
+	qc := snowflakeQueryConfig(pipeline)
+	if qc == nil {
+		return "", fmt.Errorf("pipeline %q has no Snowflake query config", name)
+	}
+	return qc.Database, nil
+}
+
+func (c *Client) GetPipelineQueryConfig(ctx context.Context, name string) (*QueryConfig, error) {
+	pipeline := &operatorv1alpha1.UnstructuredDataPipeline{}
+	err := c.client.Get(ctx, client.ObjectKey{
+		Namespace: pipelineNamespace(),
+		Name:      name,
+	}, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pipeline %q: %w", name, err)
+	}
+
+	qc := snowflakeQueryConfig(pipeline)
+	if qc == nil {
+		return nil, fmt.Errorf("pipeline %q has no Snowflake query config", name)
+	}
+	return qc, nil
 }

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -71,9 +71,10 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	}
 
 	result := make([]PipelineInfo, len(pipelineList.Items))
-	for i, pipeline := range pipelineList.Items {
+	for i := range pipelineList.Items {
+		pipeline := &pipelineList.Items[i]
 		var db string
-		if qc := snowflakeQueryConfig(&pipeline); qc != nil {
+		if qc := snowflakeQueryConfig(pipeline); qc != nil {
 			db = qc.Database
 		}
 		result[i] = PipelineInfo{


### PR DESCRIPTION
## Summary
- `get_chunks_for_embeddings` now takes `pipeline_name` + `query` instead of `database`/`schema`/`table`. It resolves the Snowflake coordinates from the pipeline CR's `VectorEmbeddingsGenerator` queryConfig.
- `list_unstructured_data_pipelines_for_user` returns only `[]{name, description}` — the minimum the LLM agent needs to pick the right pipeline. Pipeline selection instructions moved to the tool description.
- `PipelineInfo` trimmed to `name` + `description`. New `GetPipelineQueryConfig` and `GetPipelineDatabase` methods on k8s client handle coordinate lookups.

## Test plan
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all unit tests)
- [ ] Deploy MCP server and verify `list_unstructured_data_pipelines_for_user` returns `[{"name":"...","description":"..."}]`
- [ ] Verify `get_chunks_for_embeddings` with `pipeline_name` + `query` resolves coordinates and returns chunks