### PR TITLE
Skip CI approval gate for org members and collaborators

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,10 +20,21 @@ env:
   MCP_IMAGE_NAME: ${{ github.repository }}-mcp-server
 
 jobs:
+  authorize:
+    name: CI Approval Gate
+    runs-on: ubuntu-latest
+    environment: >-
+      ${{ github.event_name == 'pull_request_target'
+          && !contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'),
+                       github.event.pull_request.author_association)
+          && 'e2e-tests' || '' }}
+    steps:
+      - run: echo "Authorized"
+
   build-and-push:
     name: Build Container Image
     runs-on: ubuntu-latest
-    environment: e2e-tests
+    needs: authorize
     permissions:
       contents: read
       packages: write
@@ -119,8 +130,7 @@ jobs:
   test-e2e:
     name: Run E2E Tests
     runs-on: ubuntu-latest
-    environment: e2e-tests
-    needs: build-and-push
+    needs: [authorize, build-and-push]
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary
- Makes the `e2e-tests` environment conditional on `author_association` so that org members, collaborators, and owners skip the manual approval gate
- External contributors (`NONE`, `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, `CONTRIBUTOR`) still require approval before CI runs, protecting Snowflake secrets and GHCR push access
- Applied to both `build-and-push` and `test-e2e` jobs

## How it works
The `environment:` field uses a conditional expression:
```yaml
environment: >-
  ${{ (github.event_name == 'pull_request_target'
       && github.event.pull_request.author_association != 'MEMBER'
       && github.event.pull_request.author_association != 'COLLABORATOR'
       && github.event.pull_request.author_association != 'OWNER')
      && 'e2e-tests' || '' }}
```

| Scenario | Result |
|---|---|
| Push to main/tags | Runs immediately |
| PR from org member (`MEMBER`) | Runs immediately |
| PR from collaborator (`COLLABORATOR`) | Runs immediately |
| PR from external contributor | Requires approval |

`author_association` is computed server-side by GitHub based on org/repo membership — it cannot be spoofed by PR authors.

## Test plan
- [ ] Open a PR from an org member account and verify CI runs without approval
- [ ] Verify that the `e2e-tests` environment settings remain unchanged in repo settings