### PR TITLE
Add get_processed_document MCP tool

### DIFF
--- a/cmd/unstructured-data-mcp-server/main.go
+++ b/cmd/unstructured-data-mcp-server/main.go
@@ -82,6 +82,7 @@ func main() {
 
 	mcptools.RegisterListPipelines(mcpServer, k8sClient)
 	mcptools.RegisterGetChunksForEmbeddings(mcpServer, k8sClient, embeddingClient)
+	mcptools.RegisterGetProcessedDocument(mcpServer, k8sClient)
 
 	oauthStore := auth.NewOAuthStore()
 	oauthMiddleware := auth.NewMiddleware(provider, slog.Default())

--- a/cmd/unstructured-data-mcp-server/main.go
+++ b/cmd/unstructured-data-mcp-server/main.go
@@ -81,7 +81,7 @@ func main() {
 	})
 
 	mcptools.RegisterListPipelines(mcpServer, k8sClient)
-	mcptools.RegisterGetChunksForEmbeddings(mcpServer, embeddingClient)
+	mcptools.RegisterGetChunksForEmbeddings(mcpServer, k8sClient, embeddingClient)
 
 	oauthStore := auth.NewOAuthStore()
 	oauthMiddleware := auth.NewMiddleware(provider, slog.Default())

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -88,6 +88,14 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			}, nil, nil
 		}
 
+		if qc.Database == "" || qc.Schema == "" || qc.Table == "" {
+			log.Error("pipeline query config has empty fields", "database", qc.Database, "schema", qc.Schema, "table", qc.Table)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error: pipeline %q has incomplete Snowflake query configuration", args.PipelineName)}},
+				IsError: true,
+			}, nil, nil
+		}
+
 		log.Info("generating embedding for query")
 		result, err := embeddingClient.GenerateEmbeddings(ctx, []string{args.Query}, "float")
 		if err != nil {

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -27,23 +27,22 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/embedding"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/k8sclient"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/logger"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/snowflake"
 )
 
 type getChunksArgs struct {
-	UDPDatabase string `json:"udp_database" jsonschema:"Name of the data product database. If not known, call list_unstructured_data_pipelines_for_user first and pick the matching pipeline based on its description."`
-	Schema      string `json:"schema" jsonschema:"Snowflake schema name. If not known, call list_unstructured_data_pipelines_for_user first."`
-	Table       string `json:"table" jsonschema:"Snowflake table name. If not known, call list_unstructured_data_pipelines_for_user first."`
-	Query       string `json:"query" jsonschema:"The search query to find relevant chunks"`
+	PipelineName string `json:"pipeline_name" jsonschema:"Name of the UnstructuredDataPipeline. If not known, call list_unstructured_data_pipelines_for_user first and pick the matching pipeline based on its description."`
+	Query        string `json:"query" jsonschema:"The search query to find relevant chunks"`
 }
 
-func RegisterGetChunksForEmbeddings(s *mcp.Server, embeddingClient *embedding.HTTPClient) {
+func RegisterGetChunksForEmbeddings(s *mcp.Server, k8sClient *k8sclient.Client, embeddingClient *embedding.HTTPClient) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name: "get_chunks_for_embeddings",
-		Description: `Search for relevant text chunks in a data product using vector cosine similarity. Returns top 5 matching chunks for the given query.
-If udp_database, schema, or table are not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
-On error: report the exact error to the user and STOP. Do NOT retry with other pipelines or databases.
+		Description: `Search for relevant text chunks in a pipeline's data product using vector cosine similarity. Returns top 5 matching chunks for the given query.
+If pipeline_name is not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
+On error: report the exact error to the user and STOP. Do NOT retry with other pipelines.
 On follow-up: if the user is not satisfied, ask them which pipeline to search. Do NOT automatically try other pipelines.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getChunksArgs) (*mcp.CallToolResult, any, error) {
 		username := ""
@@ -53,12 +52,12 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		ctx = logger.NewContext(ctx, uuid.NewString(), "get_chunks_for_embeddings", username)
 		log := logger.FromContext(ctx)
 
-		log.Info("tool invoked", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table)
+		log.Info("tool invoked", "pipeline_name", args.PipelineName)
 
-		if args.UDPDatabase == "" || args.Schema == "" || args.Table == "" || args.Query == "" {
-			log.Error("missing required parameters", "udp_database", args.UDPDatabase, "schema", args.Schema, "table", args.Table, "query_empty", args.Query == "")
+		if args.PipelineName == "" || args.Query == "" {
+			log.Error("missing required parameters", "pipeline_name", args.PipelineName, "query_empty", args.Query == "")
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: "Error: udp_database, schema, table, and query are required. Call list_unstructured_data_pipelines_for_user first to get the database, schema, and table values."}},
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: pipeline_name and query are required. Call list_unstructured_data_pipelines_for_user first to get the pipeline name."}},
 				IsError: true,
 			}, nil, nil
 		}
@@ -68,6 +67,15 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			log.Error("oauth token not found in context")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "Error: oauth token not found in context"}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName)
+		if err != nil {
+			log.Error("failed to get pipeline query config", "error", err)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error resolving pipeline %q: %v", args.PipelineName, err)}},
 				IsError: true,
 			}, nil, nil
 		}
@@ -92,9 +100,9 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		log.Info("embedding generated", "vector_dimensions", len(result.Embeddings[0]))
 
 		vectorLiteral := formatVectorLiteral(result.Embeddings[0])
-		databaseName := strings.ToUpper(strings.ReplaceAll(args.UDPDatabase, "-", "_"))
-		schemaName := strings.ToUpper(args.Schema)
-		tableName := strings.ToUpper(args.Table)
+		databaseName := strings.ToUpper(strings.ReplaceAll(qc.Database, "-", "_"))
+		schemaName := strings.ToUpper(qc.Schema)
+		tableName := strings.ToUpper(qc.Table)
 
 		log.Info("searching snowflake", "database", databaseName, "schema", schemaName, "table", tableName)
 		chunks, err := snowflake.SearchChunks(ctx, oauthToken, databaseName, schemaName, tableName, vectorLiteral)
@@ -115,7 +123,7 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			}, nil, nil
 		}
 
-		log.Info("completed successfully", "database", databaseName, "chunks_found", len(chunks))
+		log.Info("completed successfully", "pipeline", args.PipelineName, "chunks_found", len(chunks))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
 				Text: fmt.Sprintf("Found %d chunks for query in %s.%s.%s:\n%s", len(chunks), databaseName, schemaName, tableName, string(jsonBytes)),

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -134,7 +134,7 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		log.Info("completed successfully", "pipeline", args.PipelineName, "chunks_found", len(chunks))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Found %d chunks for query in %s.%s.%s:\n%s", len(chunks), databaseName, schemaName, tableName, string(jsonBytes)),
+				Text: fmt.Sprintf("Found %d chunks for query in pipeline %q:\n%s", len(chunks), args.PipelineName, string(jsonBytes)),
 			}},
 		}, nil, nil
 	})

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -71,6 +71,14 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			}, nil, nil
 		}
 
+		if k8sClient == nil {
+			log.Error("kubernetes client is nil")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: kubernetes client is not initialized"}},
+				IsError: true,
+			}, nil, nil
+		}
+
 		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName)
 		if err != nil {
 			log.Error("failed to get pipeline query config", "error", err)

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/embedding"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/k8sclient"
@@ -42,6 +43,7 @@ func RegisterGetChunksForEmbeddings(s *mcp.Server, k8sClient *k8sclient.Client, 
 		Name: "get_chunks_for_embeddings",
 		Description: `Search for relevant text chunks in a pipeline's data product using vector cosine similarity. Returns top 5 matching chunks for the given query.
 If pipeline_name is not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
+After a successful search, call get_processed_document with the same pipeline_name and the file_id from the top matching chunk to retrieve the full processed document.
 On error: report the exact error to the user and STOP. Do NOT retry with other pipelines.
 On follow-up: if the user is not satisfied, ask them which pipeline to search. Do NOT automatically try other pipelines.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getChunksArgs) (*mcp.CallToolResult, any, error) {
@@ -66,7 +68,7 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		if !ok {
 			log.Error("oauth token not found in context")
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: "Error: oauth token not found in context"}},
+				Content: []mcp.Content{&mcp.TextContent{Text: errOAuthTokenNotFound}},
 				IsError: true,
 			}, nil, nil
 		}
@@ -79,7 +81,7 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			}, nil, nil
 		}
 
-		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName)
+		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName, operatorv1alpha1.StageTypeVectorEmbeddingsGenerator)
 		if err != nil {
 			log.Error("failed to get pipeline query config", "error", err)
 			return &mcp.CallToolResult{
@@ -140,9 +142,21 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		}
 
 		log.Info("completed successfully", "pipeline", args.PipelineName, "chunks_found", len(chunks))
+
+		nextStep := fmt.Sprintf(
+			"NEXT STEP: Call get_processed_document with pipeline_name=%q and file_id from the highest-scoring chunk above. Use the full markdown_content to answer the user's question.",
+			args.PipelineName,
+		)
+		if len(chunks) > 0 && chunks[0].FileID != "" {
+			nextStep = fmt.Sprintf(
+				"NEXT STEP: Call get_processed_document with pipeline_name=%q and file_id=%q. Use the full markdown_content to answer the user's question.",
+				args.PipelineName, chunks[0].FileID,
+			)
+		}
+
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Found %d chunks for query in pipeline %q:\n%s", len(chunks), args.PipelineName, string(jsonBytes)),
+				Text: fmt.Sprintf("Found %d chunks for query in pipeline %q:\n%s\n\n%s", len(chunks), args.PipelineName, string(jsonBytes), nextStep),
 			}},
 		}, nil, nil
 	})

--- a/internal/mcp/tools/get_processed_document.go
+++ b/internal/mcp/tools/get_processed_document.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/k8sclient"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/logger"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/snowflake"
+)
+
+const errOAuthTokenNotFound = "Error: oauth token not found in context"
+
+type getProcessedDocumentArgs struct {
+	PipelineName string `json:"pipeline_name" jsonschema:"Name of the UnstructuredDataPipeline. If not known, call list_unstructured_data_pipelines_for_user first and pick the matching pipeline based on its description."`
+	FileID       string `json:"file_id" jsonschema:"The file identifier to look up in the DocumentProcessor stage output"`
+}
+
+func RegisterGetProcessedDocument(s *mcp.Server, k8sClient *k8sclient.Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "get_processed_document",
+		Description: `Retrieve the processed document output for a given file_id from a pipeline's DocumentProcessor stage Snowflake table.
+If pipeline_name is not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
+On error: report the exact error to the user and STOP. Do NOT retry with other pipelines.`,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getProcessedDocumentArgs) (*mcp.CallToolResult, any, error) {
+		username := ""
+		if tokenInfo, ok := auth.TokenInfoFromContext(ctx); ok {
+			username = tokenInfo.Username
+		}
+		ctx = logger.NewContext(ctx, uuid.NewString(), "get_processed_document", username)
+		log := logger.FromContext(ctx)
+
+		log.Info("tool invoked", "pipeline_name", args.PipelineName, "file_id", args.FileID)
+
+		if args.PipelineName == "" || args.FileID == "" {
+			log.Error("missing required parameters", "pipeline_name", args.PipelineName, "file_id_empty", args.FileID == "")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: pipeline_name and file_id are required. Call list_unstructured_data_pipelines_for_user first to get the pipeline name."}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		oauthToken, ok := auth.AccessTokenFromContext(ctx)
+		if !ok {
+			log.Error("oauth token not found in context")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: errOAuthTokenNotFound}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		if k8sClient == nil {
+			log.Error("kubernetes client is nil")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: kubernetes client is not initialized"}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName, operatorv1alpha1.StageTypeDocumentProcessor)
+		if err != nil {
+			log.Error("failed to get pipeline query config", "error", err)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error resolving pipeline %q: %v", args.PipelineName, err)}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		if qc.Database == "" || qc.Schema == "" || qc.Table == "" {
+			log.Error("pipeline query config has empty fields", "database", qc.Database, "schema", qc.Schema, "table", qc.Table)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error: pipeline %q has incomplete Snowflake query configuration for DocumentProcessor stage", args.PipelineName)}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		databaseName := strings.ToUpper(strings.ReplaceAll(qc.Database, "-", "_"))
+		schemaName := strings.ToUpper(qc.Schema)
+		tableName := strings.ToUpper(qc.Table)
+
+		log.Info("querying snowflake", "database", databaseName, "schema", schemaName, "table", tableName, "file_id", args.FileID)
+		doc, err := snowflake.GetProcessedDocument(ctx, oauthToken, databaseName, schemaName, tableName, args.FileID)
+		if err != nil {
+			log.Error("failed to get processed document from snowflake", "error", err)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error fetching processed document: %v", err)}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		jsonBytes, err := json.Marshal(doc)
+		if err != nil {
+			log.Error("failed to marshal result", "error", err)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error marshaling result: %v", err)}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		log.Info("completed successfully", "pipeline", args.PipelineName, "file_id", args.FileID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{
+				Text: fmt.Sprintf("Processed document for file_id %q in pipeline %q:\n%s", args.FileID, args.PipelineName, string(jsonBytes)),
+			}},
+		}, nil, nil
+	})
+}

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -53,7 +53,7 @@ If NONE match, tell the user. Do NOT try all pipelines.`,
 			log.Error("oauth token not found in context")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
-					Text: "Error: oauth token not found in context",
+					Text: errOAuthTokenNotFound,
 				}},
 				IsError: true,
 			}, nil, nil

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -94,7 +94,7 @@ If NONE match, tell the user. Do NOT try all pipelines.`,
 			userDBs[strings.ToUpper(db.Name)] = true
 		}
 
-		var accessible []k8sclient.PipelineInfo
+		accessible := []k8sclient.PipelineInfo{}
 		for _, p := range pipelines {
 			if p.Database != "" && userDBs[strings.ToUpper(p.Database)] {
 				accessible = append(accessible, p)

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -96,11 +96,7 @@ If NONE match, tell the user. Do NOT try all pipelines.`,
 
 		var accessible []k8sclient.PipelineInfo
 		for _, p := range pipelines {
-			db, err := k8sClient.GetPipelineDatabase(ctx, p.Name)
-			if err != nil {
-				continue
-			}
-			if userDBs[strings.ToUpper(db)] {
+			if p.Database != "" && userDBs[strings.ToUpper(p.Database)] {
 				accessible = append(accessible, p)
 			}
 		}

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -96,7 +96,8 @@ If NONE match, tell the user. Do NOT try all pipelines.`,
 
 		accessible := []k8sclient.PipelineInfo{}
 		for _, p := range pipelines {
-			if p.Database != "" && userDBs[strings.ToUpper(p.Database)] {
+			dbKey := strings.ToUpper(strings.ReplaceAll(p.Database, "-", "_"))
+			if p.Database != "" && userDBs[dbKey] {
 				accessible = append(accessible, p)
 			}
 		}

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -33,8 +33,11 @@ import (
 // RegisterListPipelines registers the list_unstructured_data_pipelines_for_user MCP tool
 func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "list_unstructured_data_pipelines_for_user",
-		Description: "List all UnstructuredDataPipeline custom resources and Snowflake databases the authenticated user has access to.",
+		Name: "list_unstructured_data_pipelines_for_user",
+		Description: `List the UnstructuredDataPipelines the authenticated user has access to. Returns an array of {name, description}.
+If EXACTLY ONE pipeline matches the user's question, use it.
+If MORE THAN ONE pipeline could match, STOP and ask the user which one to use. Do NOT pick one yourself.
+If NONE match, tell the user. Do NOT try all pipelines.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		username := ""
 		if tokenInfo, ok := auth.TokenInfoFromContext(ctx); ok {
@@ -74,15 +77,6 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 			log.Warn("kubernetes client is nil, skipping pipeline listing")
 		}
 
-		// Build map of pipeline database names to pipeline info
-		pipelinesByDB := make(map[string][]k8sclient.PipelineInfo, len(pipelines))
-		for _, p := range pipelines {
-			if p.Database != "" {
-				dbKey := strings.ToUpper(p.Database)
-				pipelinesByDB[dbKey] = append(pipelinesByDB[dbKey], p)
-			}
-		}
-
 		databases, err := snowflake.ShowDatabases(ctx, oauthToken)
 		if err != nil {
 			log.Error("failed to list databases from snowflake", "error", err)
@@ -95,16 +89,19 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 		}
 		log.Info("listed databases from snowflake", "count", len(databases))
 
-		// Intersect: keep only pipelines whose database the user has access to
 		userDBs := make(map[string]bool, len(databases))
 		for _, db := range databases {
 			userDBs[strings.ToUpper(db.Name)] = true
 		}
 
 		var accessible []k8sclient.PipelineInfo
-		for dbName, plist := range pipelinesByDB {
-			if userDBs[dbName] {
-				accessible = append(accessible, plist...)
+		for _, p := range pipelines {
+			db, err := k8sClient.GetPipelineDatabase(ctx, p.Name)
+			if err != nil {
+				continue
+			}
+			if userDBs[strings.ToUpper(db)] {
+				accessible = append(accessible, p)
 			}
 		}
 
@@ -122,12 +119,7 @@ func RegisterListPipelines(s *mcp.Server, k8sClient *k8sclient.Client) {
 		log.Info("completed successfully", "total_pipelines", len(pipelines), "accessible_pipelines", len(accessible))
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Found %d accessible pipeline(s):\n%s\n\n"+
-					"IMPORTANT: If you are selecting a pipeline for a search query, you MUST follow these rules:\n"+
-					"- If EXACTLY ONE pipeline matches the user's question, use it.\n"+
-					"- If MORE THAN ONE pipeline could match, STOP and ask the user which one to use. Do NOT pick one yourself.\n"+
-					"- If NONE match, tell the user. Do NOT try all pipelines.",
-					len(accessible), string(jsonBytes)),
+				Text: string(jsonBytes),
 			}},
 		}, nil, nil
 	})

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -30,6 +30,7 @@ const defaultPipelineNamespace = "unstructured-controller-namespace"
 type PipelineInfo struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Database    string `json:"-"`
 }
 
 type QueryConfig struct {
@@ -71,30 +72,18 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 
 	result := make([]PipelineInfo, len(pipelineList.Items))
 	for i, pipeline := range pipelineList.Items {
+		var db string
+		if qc := snowflakeQueryConfig(&pipeline); qc != nil {
+			db = qc.Database
+		}
 		result[i] = PipelineInfo{
 			Name:        pipeline.Name,
 			Description: pipeline.Spec.Description,
+			Database:    db,
 		}
 	}
 
 	return result, nil
-}
-
-func (c *Client) GetPipelineDatabase(ctx context.Context, name string) (string, error) {
-	pipeline := &operatorv1alpha1.UnstructuredDataPipeline{}
-	err := c.client.Get(ctx, client.ObjectKey{
-		Namespace: pipelineNamespace(),
-		Name:      name,
-	}, pipeline)
-	if err != nil {
-		return "", fmt.Errorf("failed to get pipeline %q: %w", name, err)
-	}
-
-	qc := snowflakeQueryConfig(pipeline)
-	if qc == nil {
-		return "", fmt.Errorf("pipeline %q has no Snowflake query config", name)
-	}
-	return qc.Database, nil
 }
 
 func (c *Client) GetPipelineQueryConfig(ctx context.Context, name string) (*QueryConfig, error) {

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -29,25 +29,41 @@ const defaultPipelineNamespace = "unstructured-controller-namespace"
 
 type PipelineInfo struct {
 	Name        string `json:"name"`
-	Namespace   string `json:"namespace"`
 	Description string `json:"description"`
-	Database    string `json:"database,omitempty"`
-	Schema      string `json:"schema,omitempty"`
-	Table       string `json:"table,omitempty"`
-	Status      string `json:"status,omitempty"`
-	Message     string `json:"message,omitempty"`
+}
+
+type QueryConfig struct {
+	Database string
+	Schema   string
+	Table    string
+}
+
+func pipelineNamespace() string {
+	if ns := os.Getenv("UNSTRUCTURED_DATA_CONTROLLER_NAMESPACE"); ns != "" {
+		return ns
+	}
+	return defaultPipelineNamespace
+}
+
+func snowflakeQueryConfig(pipeline *operatorv1alpha1.UnstructuredDataPipeline) *QueryConfig {
+	for _, stage := range pipeline.Spec.Stages {
+		if stage.Type == operatorv1alpha1.StageTypeVectorEmbeddingsGenerator &&
+			stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
+			return &QueryConfig{
+				Database: stage.QueryConfig.Snowflake.Database,
+				Schema:   stage.QueryConfig.Snowflake.Schema,
+				Table:    stage.QueryConfig.Snowflake.Table,
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	pipelineList := &operatorv1alpha1.UnstructuredDataPipelineList{}
 
-	namespace := os.Getenv("UNSTRUCTURED_DATA_CONTROLLER_NAMESPACE")
-	if namespace == "" {
-		namespace = defaultPipelineNamespace
-	}
-
 	err := c.client.List(ctx, pipelineList, &client.ListOptions{
-		Namespace: namespace,
+		Namespace: pipelineNamespace(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pipelines: %w", err)
@@ -55,32 +71,45 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 
 	result := make([]PipelineInfo, len(pipelineList.Items))
 	for i, pipeline := range pipelineList.Items {
-		info := PipelineInfo{
+		result[i] = PipelineInfo{
 			Name:        pipeline.Name,
-			Namespace:   pipeline.Namespace,
 			Description: pipeline.Spec.Description,
 		}
-
-		for _, stage := range pipeline.Spec.Stages {
-			if stage.Type == operatorv1alpha1.StageTypeVectorEmbeddingsGenerator &&
-				stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
-				info.Database = stage.QueryConfig.Snowflake.Database
-				info.Schema = stage.QueryConfig.Snowflake.Schema
-				info.Table = stage.QueryConfig.Snowflake.Table
-				break
-			}
-		}
-
-		for _, condition := range pipeline.Status.Conditions {
-			if condition.Type == "UnstructuredDataPipelineReady" {
-				info.Status = string(condition.Status)
-				info.Message = condition.Message
-				break
-			}
-		}
-
-		result[i] = info
 	}
 
 	return result, nil
+}
+
+func (c *Client) GetPipelineDatabase(ctx context.Context, name string) (string, error) {
+	pipeline := &operatorv1alpha1.UnstructuredDataPipeline{}
+	err := c.client.Get(ctx, client.ObjectKey{
+		Namespace: pipelineNamespace(),
+		Name:      name,
+	}, pipeline)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pipeline %q: %w", name, err)
+	}
+
+	qc := snowflakeQueryConfig(pipeline)
+	if qc == nil {
+		return "", fmt.Errorf("pipeline %q has no Snowflake query config", name)
+	}
+	return qc.Database, nil
+}
+
+func (c *Client) GetPipelineQueryConfig(ctx context.Context, name string) (*QueryConfig, error) {
+	pipeline := &operatorv1alpha1.UnstructuredDataPipeline{}
+	err := c.client.Get(ctx, client.ObjectKey{
+		Namespace: pipelineNamespace(),
+		Name:      name,
+	}, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pipeline %q: %w", name, err)
+	}
+
+	qc := snowflakeQueryConfig(pipeline)
+	if qc == nil {
+		return nil, fmt.Errorf("pipeline %q has no Snowflake query config", name)
+	}
+	return qc, nil
 }

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -71,9 +71,10 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	}
 
 	result := make([]PipelineInfo, len(pipelineList.Items))
-	for i, pipeline := range pipelineList.Items {
+	for i := range pipelineList.Items {
+		pipeline := &pipelineList.Items[i]
 		var db string
-		if qc := snowflakeQueryConfig(&pipeline); qc != nil {
+		if qc := snowflakeQueryConfig(pipeline); qc != nil {
 			db = qc.Database
 		}
 		result[i] = PipelineInfo{

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -46,9 +46,11 @@ func pipelineNamespace() string {
 	return defaultPipelineNamespace
 }
 
-func snowflakeQueryConfig(pipeline *operatorv1alpha1.UnstructuredDataPipeline) *QueryConfig {
+func snowflakeQueryConfig(
+	pipeline *operatorv1alpha1.UnstructuredDataPipeline, stageType operatorv1alpha1.StageType,
+) *QueryConfig {
 	for _, stage := range pipeline.Spec.Stages {
-		if stage.Type == operatorv1alpha1.StageTypeVectorEmbeddingsGenerator &&
+		if stage.Type == stageType &&
 			stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
 			return &QueryConfig{
 				Database: stage.QueryConfig.Snowflake.Database,
@@ -74,7 +76,7 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	for i := range pipelineList.Items {
 		pipeline := &pipelineList.Items[i]
 		var db string
-		if qc := snowflakeQueryConfig(pipeline); qc != nil {
+		if qc := snowflakeQueryConfig(pipeline, operatorv1alpha1.StageTypeVectorEmbeddingsGenerator); qc != nil {
 			db = qc.Database
 		}
 		result[i] = PipelineInfo{
@@ -87,7 +89,9 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	return result, nil
 }
 
-func (c *Client) GetPipelineQueryConfig(ctx context.Context, name string) (*QueryConfig, error) {
+func (c *Client) GetPipelineQueryConfig(
+	ctx context.Context, name string, stageType operatorv1alpha1.StageType,
+) (*QueryConfig, error) {
 	pipeline := &operatorv1alpha1.UnstructuredDataPipeline{}
 	err := c.client.Get(ctx, client.ObjectKey{
 		Namespace: pipelineNamespace(),
@@ -97,9 +101,9 @@ func (c *Client) GetPipelineQueryConfig(ctx context.Context, name string) (*Quer
 		return nil, fmt.Errorf("failed to get pipeline %q: %w", name, err)
 	}
 
-	qc := snowflakeQueryConfig(pipeline)
+	qc := snowflakeQueryConfig(pipeline, stageType)
 	if qc == nil {
-		return nil, fmt.Errorf("pipeline %q has no Snowflake query config", name)
+		return nil, fmt.Errorf("pipeline %q has no Snowflake query config for stage type %q", name, stageType)
 	}
 	return qc, nil
 }

--- a/pkg/snowflake/documents.go
+++ b/pkg/snowflake/documents.go
@@ -21,16 +21,14 @@ import (
 	"fmt"
 )
 
-type ChunkResult struct {
-	FileID     string `json:"file_id" db:"file_id"`
-	ChunkIndex string `json:"chunk_index" db:"chunk_index"`
-	ChunkText  string `json:"chunk_text" db:"chunk_text"`
-	Score      string `json:"score" db:"score"`
+type ProcessedDocumentResult struct {
+	FileID          string `json:"file_id" db:"file_id"`
+	MarkdownContent string `json:"markdown_content" db:"markdown_content"`
 }
 
-func SearchChunks(
-	ctx context.Context, oauthToken, database, schema, table, vectorLiteral string,
-) ([]ChunkResult, error) {
+func GetProcessedDocument(
+	ctx context.Context, oauthToken, database, schema, table, fileID string,
+) (*ProcessedDocumentResult, error) {
 	db, err := openConnection(oauthToken)
 	if err != nil {
 		return nil, err
@@ -38,16 +36,22 @@ func SearchChunks(
 	defer func() { _ = db.Close() }()
 
 	query := fmt.Sprintf(
-		`SELECT FILE_ID, CHUNK_INDEX, CHUNK_TEXT, VECTOR_COSINE_SIMILARITY(EMBEDDING, %s::VECTOR(FLOAT,768)) AS score `+
-			`FROM %s.%s.%s ORDER BY score DESC LIMIT 5`,
-		vectorLiteral, database, schema, table,
+		`SELECT FILE_ID, MARKDOWN_CONTENT FROM %s.%s.%s WHERE FILE_ID = ? LIMIT 1`,
+		database, schema, table,
 	)
 
-	rows, err := db.QueryContext(ctx, query)
+	rows, err := db.QueryContext(ctx, query, fileID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute vector search: %w", err)
+		return nil, fmt.Errorf("failed to query processed document: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	return scanRows[ChunkResult](rows)
+	results, err := scanRows[ProcessedDocumentResult](rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no processed document found for file_id %q", fileID)
+	}
+	return &results[0], nil
 }


### PR DESCRIPTION
## Summary
- Adds a new `get_processed_document` MCP tool that retrieves full markdown content from a pipeline's DocumentProcessor stage Snowflake table by `file_id`
- Chains `get_chunks` → `get_processed_document`: chunk results now include `file_id` and guide the LLM to fetch the full document as a follow-up
- Generalizes `GetPipelineQueryConfig` to accept a stage type parameter, enabling reuse across different pipeline stages

## Test plan
- [ ] Verify `get_processed_document` returns correct markdown content for a known `file_id`
- [ ] Verify `get_chunks` returns `file_id` in results and the `NEXT STEP` prompt guides correctly
- [ ] Verify `get_processed_document` returns appropriate errors for missing pipeline, missing file_id, and pipelines without a DocumentProcessor stage
- [ ] Verify `list_pipelines` and `get_chunks` still work as before