### PR TITLE
Add get_processed_document MCP tool and chain it from get_chunks

### DIFF
--- a/cmd/unstructured-data-mcp-server/main.go
+++ b/cmd/unstructured-data-mcp-server/main.go
@@ -82,6 +82,7 @@ func main() {
 
 	mcptools.RegisterListPipelines(mcpServer, k8sClient)
 	mcptools.RegisterGetChunksForEmbeddings(mcpServer, k8sClient, embeddingClient)
+	mcptools.RegisterGetProcessedDocument(mcpServer, k8sClient)
 
 	oauthStore := auth.NewOAuthStore()
 	oauthMiddleware := auth.NewMiddleware(provider, slog.Default(), oauthCfg.DisableIntrospection)

--- a/internal/mcp/tools/get_chunks.go
+++ b/internal/mcp/tools/get_chunks.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/embedding"
 	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/k8sclient"
@@ -42,6 +43,7 @@ func RegisterGetChunksForEmbeddings(s *mcp.Server, k8sClient *k8sclient.Client, 
 		Name: "get_chunks_for_embeddings",
 		Description: `Search for relevant text chunks in a pipeline's data product using vector cosine similarity. Returns top 5 matching chunks for the given query.
 If pipeline_name is not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
+If the returned chunks are not sufficient to answer the user's question, you may call get_processed_document with the same pipeline_name and the file_id from the top matching chunk to retrieve the full processed document for more context.
 On error: report the exact error to the user and STOP. Do NOT retry with other pipelines.
 On follow-up: if the user is not satisfied, ask them which pipeline to search. Do NOT automatically try other pipelines.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getChunksArgs) (*mcp.CallToolResult, any, error) {
@@ -66,7 +68,7 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		if !ok {
 			log.Error("oauth token not found in context")
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: "Error: oauth token not found in context"}},
+				Content: []mcp.Content{&mcp.TextContent{Text: errOAuthTokenNotFound}},
 				IsError: true,
 			}, nil, nil
 		}
@@ -79,7 +81,7 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 			}, nil, nil
 		}
 
-		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName)
+		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName, operatorv1alpha1.StageTypeVectorEmbeddingsGenerator)
 		if err != nil {
 			log.Error("failed to get pipeline query config", "error", err)
 			return &mcp.CallToolResult{
@@ -140,9 +142,18 @@ On follow-up: if the user is not satisfied, ask them which pipeline to search. D
 		}
 
 		log.Info("completed successfully", "pipeline", args.PipelineName, "chunks_found", len(chunks))
+
+		var nextStep string
+		if len(chunks) > 0 {
+			nextStep = fmt.Sprintf(
+				"\n\nTIP: To retrieve the full processed document, call get_processed_document with pipeline_name=%q and the file_id from the most relevant chunk above.",
+				args.PipelineName,
+			)
+		}
+
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{
-				Text: fmt.Sprintf("Found %d chunks for query in pipeline %q:\n%s", len(chunks), args.PipelineName, string(jsonBytes)),
+				Text: fmt.Sprintf("Found %d chunks for query in pipeline %q:\n%s%s", len(chunks), args.PipelineName, string(jsonBytes), nextStep),
 			}},
 		}, nil, nil
 	})

--- a/internal/mcp/tools/get_processed_document.go
+++ b/internal/mcp/tools/get_processed_document.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	operatorv1alpha1 "github.com/redhat-data-and-ai/unstructured-data-controller/api/v1alpha1"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/auth"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/k8sclient"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/logger"
+	"github.com/redhat-data-and-ai/unstructured-data-controller/pkg/snowflake"
+)
+
+const errOAuthTokenNotFound = "Error: oauth token not found in context"
+
+type getProcessedDocumentArgs struct {
+	PipelineName string `json:"pipeline_name" jsonschema:"Name of the UnstructuredDataPipeline. If not known, call list_unstructured_data_pipelines_for_user first and pick the matching pipeline based on its description."`
+	FileID       string `json:"file_id" jsonschema:"The file identifier to look up in the DocumentProcessor stage output"`
+}
+
+func RegisterGetProcessedDocument(s *mcp.Server, k8sClient *k8sclient.Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "get_processed_document",
+		Description: `Retrieve the processed document output for a given file_id from a pipeline's DocumentProcessor stage Snowflake table.
+If pipeline_name is not known, call list_unstructured_data_pipelines_for_user first and follow the instructions in its response.
+On error: report the exact error to the user and STOP. Do NOT retry with other pipelines.`,
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getProcessedDocumentArgs) (*mcp.CallToolResult, any, error) {
+		username := ""
+		if tokenInfo, ok := auth.TokenInfoFromContext(ctx); ok {
+			username = tokenInfo.Username
+		}
+		ctx = logger.NewContext(ctx, uuid.NewString(), "get_processed_document", username)
+		log := logger.FromContext(ctx)
+
+		log.Info("tool invoked", "pipeline_name", args.PipelineName, "file_id", args.FileID)
+
+		if args.PipelineName == "" || args.FileID == "" {
+			log.Error("missing required parameters", "pipeline_name", args.PipelineName, "file_id_empty", args.FileID == "")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: pipeline_name and file_id are required. Call list_unstructured_data_pipelines_for_user first to get the pipeline name."}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		oauthToken, ok := auth.AccessTokenFromContext(ctx)
+		if !ok {
+			log.Error("oauth token not found in context")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: errOAuthTokenNotFound}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		if k8sClient == nil {
+			log.Error("kubernetes client is nil")
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: unable to fetch pipeline information"}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		qc, err := k8sClient.GetPipelineQueryConfig(ctx, args.PipelineName, operatorv1alpha1.StageTypeDocumentProcessor)
+		if err != nil {
+			log.Error("failed to get pipeline query config", "error", err)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error: unable to resolve configuration for pipeline %q. Please verify the pipeline name is correct.", args.PipelineName)}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		if qc.Database == "" || qc.Schema == "" || qc.Table == "" {
+			log.Error("pipeline query config has empty fields", "database", qc.Database, "schema", qc.Schema, "table", qc.Table)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Unable to retrieve the document, please check again in some time"}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		databaseName := strings.ToUpper(strings.ReplaceAll(qc.Database, "-", "_"))
+		schemaName := strings.ToUpper(qc.Schema)
+		tableName := strings.ToUpper(qc.Table)
+
+		log.Info("querying snowflake", "database", databaseName, "schema", schemaName, "table", tableName, "file_id", args.FileID)
+		doc, err := snowflake.GetProcessedDocument(ctx, oauthToken, databaseName, schemaName, tableName, args.FileID)
+		if err != nil {
+			log.Error("failed to get processed document from snowflake", "error", err)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error: unable to retrieve the processed document for file_id %q. Please verify the file_id is correct.", args.FileID)}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		jsonBytes, err := json.Marshal(doc)
+		if err != nil {
+			log.Error("failed to marshal result", "error", err)
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "Error: unable to process the document result"}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		log.Info("completed successfully", "pipeline", args.PipelineName, "file_id", args.FileID)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{
+				Text: fmt.Sprintf("Processed document for file_id %q in pipeline %q:\n%s", args.FileID, args.PipelineName, string(jsonBytes)),
+			}},
+		}, nil, nil
+	})
+}

--- a/internal/mcp/tools/list_pipelines.go
+++ b/internal/mcp/tools/list_pipelines.go
@@ -53,7 +53,7 @@ If NONE match, tell the user. Do NOT try all pipelines.`,
 			log.Error("oauth token not found in context")
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{
-					Text: "Error: oauth token not found in context",
+					Text: errOAuthTokenNotFound,
 				}},
 				IsError: true,
 			}, nil, nil

--- a/pkg/k8sclient/pipeline.go
+++ b/pkg/k8sclient/pipeline.go
@@ -46,9 +46,11 @@ func pipelineNamespace() string {
 	return defaultPipelineNamespace
 }
 
-func snowflakeQueryConfig(pipeline *operatorv1alpha1.UnstructuredDataPipeline) *QueryConfig {
+func snowflakeQueryConfig(
+	pipeline *operatorv1alpha1.UnstructuredDataPipeline, stageType operatorv1alpha1.StageType,
+) *QueryConfig {
 	for _, stage := range pipeline.Spec.Stages {
-		if stage.Type == operatorv1alpha1.StageTypeVectorEmbeddingsGenerator &&
+		if stage.Type == stageType &&
 			stage.QueryConfig != nil && stage.QueryConfig.Snowflake != nil {
 			return &QueryConfig{
 				Database: stage.QueryConfig.Snowflake.Database,
@@ -74,7 +76,7 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	for i := range pipelineList.Items {
 		pipeline := &pipelineList.Items[i]
 		var db string
-		if qc := snowflakeQueryConfig(pipeline); qc != nil {
+		if qc := snowflakeQueryConfig(pipeline, operatorv1alpha1.StageTypeVectorEmbeddingsGenerator); qc != nil {
 			db = qc.Database
 		}
 		result[i] = PipelineInfo{
@@ -87,7 +89,9 @@ func (c *Client) ListPipelines(ctx context.Context) ([]PipelineInfo, error) {
 	return result, nil
 }
 
-func (c *Client) GetPipelineQueryConfig(ctx context.Context, name string) (*QueryConfig, error) {
+func (c *Client) GetPipelineQueryConfig(
+	ctx context.Context, name string, stageType operatorv1alpha1.StageType,
+) (*QueryConfig, error) {
 	pipeline := &operatorv1alpha1.UnstructuredDataPipeline{}
 	err := c.client.Get(ctx, client.ObjectKey{
 		Namespace: pipelineNamespace(),
@@ -97,9 +101,9 @@ func (c *Client) GetPipelineQueryConfig(ctx context.Context, name string) (*Quer
 		return nil, fmt.Errorf("failed to get pipeline %q: %w", name, err)
 	}
 
-	qc := snowflakeQueryConfig(pipeline)
+	qc := snowflakeQueryConfig(pipeline, stageType)
 	if qc == nil {
-		return nil, fmt.Errorf("pipeline %q has no Snowflake query config", name)
+		return nil, fmt.Errorf("pipeline %q has no Snowflake query config for stage type %q", name, stageType)
 	}
 	return qc, nil
 }

--- a/pkg/snowflake/documents.go
+++ b/pkg/snowflake/documents.go
@@ -21,16 +21,14 @@ import (
 	"fmt"
 )
 
-type ChunkResult struct {
-	FileID     string `json:"file_id" db:"file_id"`
-	ChunkIndex string `json:"chunk_index" db:"chunk_index"`
-	ChunkText  string `json:"chunk_text" db:"chunk_text"`
-	Score      string `json:"score" db:"score"`
+type ProcessedDocumentResult struct {
+	FileID          string `json:"file_id" db:"file_id"`
+	MarkdownContent string `json:"markdown_content" db:"markdown_content"`
 }
 
-func SearchChunks(
-	ctx context.Context, oauthToken, database, schema, table, vectorLiteral string,
-) ([]ChunkResult, error) {
+func GetProcessedDocument(
+	ctx context.Context, oauthToken, database, schema, table, fileID string,
+) (*ProcessedDocumentResult, error) {
 	db, err := openConnection(oauthToken)
 	if err != nil {
 		return nil, err
@@ -38,16 +36,22 @@ func SearchChunks(
 	defer func() { _ = db.Close() }()
 
 	query := fmt.Sprintf(
-		`SELECT FILE_ID, CHUNK_INDEX, CHUNK_TEXT, VECTOR_COSINE_SIMILARITY(EMBEDDING, %s::VECTOR(FLOAT,768)) AS score `+
-			`FROM %s.%s.%s ORDER BY score DESC LIMIT 5`,
-		vectorLiteral, database, schema, table,
+		`SELECT FILE_ID, MARKDOWN_CONTENT FROM %s.%s.%s WHERE FILE_ID = ? LIMIT 1`,
+		database, schema, table,
 	)
 
-	rows, err := db.QueryContext(ctx, query)
+	rows, err := db.QueryContext(ctx, query, fileID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute vector search: %w", err)
+		return nil, fmt.Errorf("failed to query processed document: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	return scanRows[ChunkResult](rows)
+	results, err := scanRows[ProcessedDocumentResult](rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no processed document found for file_id %q", fileID)
+	}
+	return &results[0], nil
 }


### PR DESCRIPTION
## Summary

- New `get_processed_document` MCP tool retrieves full markdown content from the DocumentProcessor stage table by `file_id`
- `get_chunks_for_embeddings` now returns `file_id` in results and prompts the LLM agent to call `get_processed_document` as a follow-up for the full document
- Generalize `GetPipelineQueryConfig` to accept a stage type parameter so it works for both VectorEmbeddingsGenerator and DocumentProcessor stages
- Add `snowflake.GetProcessedDocument()` to query the processed document table
- Extract shared `errOAuthTokenNotFound` constant across MCP tools

## Test plan

- [ ] Verify `get_chunks_for_embeddings` returns `file_id` in chunk results
- [ ] Verify `get_chunks_for_embeddings` response includes the NEXT STEP instruction to call `get_processed_document`
- [ ] Verify `get_processed_document` retrieves the correct document by `file_id` from the DocumentProcessor stage table
- [ ] Verify `GetPipelineQueryConfig` correctly resolves query config for both `StageTypeVectorEmbeddingsGenerator` and `StageTypeDocumentProcessor`
- [ ] Verify error handling for missing pipeline, missing query config, and missing document
