### PR TITLE
Set Default warehouse for snowflake session

### DIFF
--- a/pkg/snowflake/client.go
+++ b/pkg/snowflake/client.go
@@ -31,11 +31,17 @@ func openConnection(oauthToken string) (*sql.DB, error) {
 		return nil, errors.New("SNOWFLAKE_ACCOUNT environment variable not set")
 	}
 
+	warehouse := os.Getenv("SNOWFLAKE_WAREHOUSE")
+	if warehouse == "" {
+		warehouse = "DEFAULT"
+	}
+
 	cfg := &gosnowflake.Config{
 		Account:       account,
 		Authenticator: gosnowflake.AuthTypeOAuth,
 		Token:         oauthToken,
 		Role:          "PUBLIC",
+		Warehouse:     warehouse,
 		OCSPFailOpen:  gosnowflake.OCSPFailOpenTrue,
 	}
 


### PR DESCRIPTION
At the moment no default warehouse is being set for the snowflake session which leads to the problem where if the default warehouse is not set for the user then queries fail.

Setting the default warehouse for the session to `DEFAULT`